### PR TITLE
Adding plot interaction and "measure now" intensity / shape

### DIFF
--- a/napari_clusters_plotter/_dock_widget.py
+++ b/napari_clusters_plotter/_dock_widget.py
@@ -131,7 +131,7 @@ class Widget(QWidget):
         reg_props_container.layout().addWidget(label_reg_props)
 
         self.reg_props_choice_list = QComboBox()
-        self.reg_props_choice_list.addItems(['   ', 'Measure now', 'Upload file'])
+        self.reg_props_choice_list.addItems(['   ', 'Measure now (intensity)', 'Measure now (shape)', 'Measure now (intensity + shape)', 'Upload file'])
         reg_props_container.layout().addWidget(self.reg_props_choice_list)
 
         # selection of the clustering methods
@@ -318,12 +318,24 @@ class Widget(QWidget):
             return
 
         # depending on settings,...
-        if self.reg_props_choice_list.currentText() == 'Upload file':
+        region_props_source = self.reg_props_choice_list.currentText()
+        if region_props_source == 'Upload file':
             # load regions region properties from file
             reg_props = pd.read_csv(regpropsfile)
-        elif self.reg_props_choice_list.currentText() == 'Measure now':
+        elif 'Measure now' in region_props_source:
             # or determine it now using clEsperanto
             reg_props = pd.DataFrame(cle.statistics_of_labelled_pixels(image, labels))
+
+            # and select columns, depending on if intensities and/or shape were selected
+            columns = []
+            if 'intensity' in region_props_source:
+                columns = columns + ['min_intensity', 'max_intensity', 'sum_intensity',
+                            'mean_intensity', 'standard_deviation_intensity']
+            if 'shape' in region_props_source:
+                columns = columns + ['area', 'mean_distance_to_centroid',
+                                     'max_distance_to_centroid', 'mean_max_distance_to_centroid_ratio']
+            reg_props = reg_props[columns]
+            print(list(reg_props.keys()))
         else:
             warnings.warn("No measurements.")
             return


### PR DESCRIPTION
Hey Laura @lazigu ,

I just played a bit with the plugin, and I LOVE it! I had to fix a little bug, as "Measure now" wasn't working yet. I implemented it in a way that the user can choose if intensities and/or shapes are measured. When clustering for shape, the screenshot below is the result. It can differentiate between small and large blobs!
![image](https://user-images.githubusercontent.com/12660498/137595086-28193674-dd4b-447c-8bd2-7707a6a501a9.png)

Furthermore, I implemented interaction with the plot, so that one can click in it and add additional points. That's of course just for testing, but I assume drawing a rectangle is close and then we could interactively do manual clustering ;-)
![image](https://user-images.githubusercontent.com/12660498/137595175-7a6f7845-f757-4bfa-ba2a-09ec8eb1dee2.png)


Let me know what you think!

And have a great weekend! If you read this on Saturday/Sunday, no need to answer until you're back in the office and/or have time.

Best,
Robert
