### PR TITLE
remove spacing between widgets

### DIFF
--- a/napari_clusters_plotter/_dock_widget.py
+++ b/napari_clusters_plotter/_dock_widget.py
@@ -215,7 +215,6 @@ class Widget(QWidget):
         self.layout().addWidget(self.kmeans_settings_container2)
         self.layout().addWidget(run_widget)
         self.layout().setSpacing(0) # <--- not working # it works indeed, it removes two pixels, Robert :-)
-        self.layout().setContentsMargins(0,0,0,0)
         # go through all widgets again and make them stick to each other
         for i in range(self.layout().count()):
             item = self.layout().itemAt(i).widget()


### PR DESCRIPTION
Hi Laura @lazigu ,

I saw one of your todos and felt challenged. I did remove the spacers between widgets earlier. It took me a moment, but eventually, I figured out. I actually like that the widgets now stick to each other. No pixel wasted ;-)
![image](https://user-images.githubusercontent.com/12660498/137595794-2fda3e1c-6abb-4484-9689-dd2f8e6293f2.png)

Let me know what you think!

Best,
Robert
