### PR TITLE
Reuse table from napari skimage regionprops instead of copying its code

### DIFF
--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -13,77 +13,8 @@ def widgets_inactive(*widgets, active):
 
 
 def show_table(viewer, labels_layer):
-    dock_widget = _table_to_widget(labels_layer.properties, labels_layer)
-    viewer.window.add_dock_widget(dock_widget, name='Region properties table', area='right')
-
-
-# adapted from Robert Haase napari-skimage-regionprops
-def _table_to_widget(table: dict, labels_layer: napari.layers.Labels) -> QWidget:
-    """
-    Takes a table given as dictionary with strings as keys and numeric arrays as values and returns a QWidget which
-    contains a QTableWidget with that data.
-    """
-    view = QTableWidget(len(next(iter(table.values()))), len(table))
-    for i, column in enumerate(table.keys()):
-        view.setItem(0, i, QTableWidgetItem(column))
-        for j, value in enumerate(table.get(column)):
-            view.setItem(j + 1, i, QTableWidgetItem(str(value)))
-
-    if labels_layer is not None:
-
-        @view.clicked.connect
-        def clicked_table():
-            row = view.currentRow()
-            if "label" in table:
-                label = table["label"][row]-1
-                print("Selected label: " + str(label))
-            else:
-                warnings.warn("Not possible to show selected label.")
-                return
-            labels_layer.selected_label = label
-
-        def after_labels_clicked():
-            row = view.currentRow()
-            if "label" in table:
-                label = table["label"][row]-1
-                print("Selected label: " + str(label))
-                if label != labels_layer.selected_label:
-                    for r, layer in enumerate(table["label"]):
-                        if layer == labels_layer.selected_label:
-                            view.setCurrentCell(r, view.currentColumn())
-                            break
-
-            else:
-                warnings.warn("Not possible to show selected label.")
-                return
-
-
-        @labels_layer.mouse_drag_callbacks.append
-        def clicked_labels(event, event1):
-            # We need to run this lagter as the labels_layer.selected_label isn't changed yet.
-            QTimer.singleShot(200, after_labels_clicked)
-
-    copy_button = QPushButton("Copy to clipboard")
-
-    @copy_button.clicked.connect
-    def copy_trigger():
-        DataFrame(table).to_clipboard()
-
-    save_button = QPushButton("Save as csv...")
-
-    @save_button.clicked.connect
-    def save_trigger():
-        filename, _ = QFileDialog.getSaveFileName(save_button, "Save as csv...", ".", "*.csv")
-        DataFrame(table).to_csv(filename)
-
-    widget_table = QWidget()
-    widget_table.setWindowTitle("region properties")
-    widget_table.setLayout(QGridLayout())
-    widget_table.layout().addWidget(copy_button)
-    widget_table.layout().addWidget(save_button)
-    widget_table.layout().addWidget(view)
-
-    return widget_table
+    from napari_skimage_regionprops import add_table
+    add_table(labels_layer, viewer)
 
 
 # function for generating image labelled by clusters given the label image and the cluster prediction list

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     umap-learn
     scikit-learn
     napari-tools-menu
-    napari-skimage-regionprops
+    napari-skimage-regionprops>=0.2.0
 
 
 [options.entry_points] 

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,7 @@ install_requires =
     umap-learn
     scikit-learn
     napari-tools-menu
+    napari-skimage-regionprops
 
 
 [options.entry_points] 


### PR DESCRIPTION
Hi Laura @lazigu ,

here comes a PR for the issues with tables we had. E.g. the table column headers are now longer within the table but rather real column headers. With this, also selecting a cell and highlighting it in the image should work again. To achieve this, your plugin will use the table within napari-skimage-regionprops. And if we see issues again, we only need to fix it in one place (there) :-)

Let me know what you think!

Best,
Robert