### PR TITLE
Add questions marks and tooltips

### DIFF
--- a/napari_clusters_plotter/_dimensionality_reduction.py
+++ b/napari_clusters_plotter/_dimensionality_reduction.py
@@ -55,24 +55,51 @@ class DimensionalityReductionWidget(QWidget):
         self.n_neighbors_container = QWidget()
         self.n_neighbors_container.setLayout(QHBoxLayout())
         self.n_neighbors_container.layout().addWidget(QLabel("Number of neighbors"))
+        self.n_neighbors_container.layout().addStretch()
         self.n_neighbors = create_widget(widget_type="SpinBox",
                                          name='n_neighbors',
                                          value=DEFAULTS['n_neighbors'],
                                          options=dict(min=2, step=1))
 
+        help_n_neighbors = QLabel()
+        help_n_neighbors.setOpenExternalLinks(True)
+        help_n_neighbors.setText('<a href="https://umap-learn.readthedocs.io/en/latest/parameters.html#n-neighbors" '
+                                 'style="text-decoration:none; color:white"><b>?</b></a>')
+
+        help_n_neighbors.setToolTip(
+            "The size of local neighborhood (in terms of number of neighboring sample points) used for manifold "
+            "approximation. Larger values result in more global views of the manifold, while smaller values should be "
+            "in the range 2 to 100. Click on the question mark to read more.")
+
+        self.n_neighbors.native.setMaximumWidth(70)
         self.n_neighbors_container.layout().addWidget(self.n_neighbors.native)
+        self.n_neighbors_container.layout().addWidget(help_n_neighbors)
         self.n_neighbors_container.setVisible(False)
 
         # selection of the level of perplexity. Higher values should be chosen when handling large datasets
         self.perplexity_container = QWidget()
         self.perplexity_container.setLayout(QHBoxLayout())
         self.perplexity_container.layout().addWidget(QLabel("Perplexity"))
+        self.perplexity_container.layout().addStretch()
         self.perplexity = create_widget(widget_type="SpinBox",
                                         name='perplexity',
                                         value=DEFAULTS['perplexity'],
                                         options=dict(min=1, step=1))
 
+        help_perplexity = QLabel()
+        help_perplexity.setOpenExternalLinks(True)
+        help_perplexity.setText('<a href="https://distill.pub/2016/misread-tsne/" '
+                                'style="text-decoration:none; color:white"><b>?</b></a>')
+
+        help_perplexity.setToolTip(
+            "The perplexity is related to the number of nearest neighbors that is used in other manifold learning "
+            "algorithms. Larger datasets usually require a larger perplexity. Consider selecting a value between 5 and "
+            "50. Different values can result in significantly different results. "
+            "Click on the question mark to read more.")
+
+        self.perplexity.native.setMaximumWidth(70)
         self.perplexity_container.layout().addWidget(self.perplexity.native)
+        self.perplexity_container.layout().addWidget(help_perplexity)
         self.perplexity_container.setVisible(False)
 
         # select properties of which to produce a dimension reduce version

--- a/napari_clusters_plotter/_kmeans_clustering.py
+++ b/napari_clusters_plotter/_kmeans_clustering.py
@@ -101,25 +101,49 @@ class ClusteringWidget(QWidget):
         self.hdbscan_settings_container_size = QWidget()
         self.hdbscan_settings_container_size.setLayout(QHBoxLayout())
         self.hdbscan_settings_container_size.layout().addWidget(QLabel("Minimum size of clusters"))
+        self.hdbscan_settings_container_size.layout().addStretch()
         self.hdbscan_min_clusters_size = create_widget(widget_type="SpinBox",
                                                        name="hdbscan_min_clusters_size",
                                                        value=DEFAULTS["hdbscan_min_clusters_size"],
                                                        options={"min": 2, "step": 1})
 
+        help_min_clusters_size = QLabel()
+        help_min_clusters_size.setOpenExternalLinks(True)
+        help_min_clusters_size.setText('<a href="https://hdbscan.readthedocs.io/en/latest/parameter_selection.html" '
+                                       'style="text-decoration:none; color:white"><b>?</b></a>')
+
+        help_min_clusters_size.setToolTip(
+            "The minimum size of clusters; single linkage splits that contain fewer points than this will be "
+            "considered points falling out of a cluster rather than a cluster splitting into two new clusters. "
+            " Click on question mark to read more.")
+
+        self.hdbscan_min_clusters_size.native.setMaximumWidth(70)
         self.hdbscan_settings_container_size.layout().addWidget(self.hdbscan_min_clusters_size.native)
+        self.hdbscan_settings_container_size.layout().addWidget(help_min_clusters_size)
         self.hdbscan_settings_container_size.setVisible(False)
 
         # selection of the minimum number of samples in a neighborhood for a point to be considered as a core point
         self.hdbscan_settings_container_min_nr = QWidget()
         self.hdbscan_settings_container_min_nr.setLayout(QHBoxLayout())
         self.hdbscan_settings_container_min_nr.layout().addWidget(QLabel("Minimum number of samples"))
-        # hdbscan_min_nr_samples defaults to the min_cluster_size
+        self.hdbscan_settings_container_min_nr.layout().addStretch()
         self.hdbscan_min_nr_samples = create_widget(widget_type="SpinBox",
                                                     name="hdbscan_min_nr_samples",
                                                     value=self.hdbscan_min_clusters_size.value,
                                                     options={"min": 1, "step": 1})
+        help_min_nr_samples = QLabel()
+        help_min_nr_samples.setOpenExternalLinks(True)
+        help_min_nr_samples.setText(
+            '<a href="https://hdbscan.readthedocs.io/en/latest/parameter_selection.html#selecting-min-samples" '
+            'style="text-decoration:none; color:white"><b>?</b></a>')
 
+        help_min_nr_samples.setToolTip("The number of samples in a neighbourhood for a point to be considered a core "
+                                       "point. By default it is equal to the minimum cluster size. Click on the "
+                                       "question mark to read more.")
+
+        self.hdbscan_min_nr_samples.native.setMaximumWidth(70)
         self.hdbscan_settings_container_min_nr.layout().addWidget(self.hdbscan_min_nr_samples.native)
+        self.hdbscan_settings_container_min_nr.layout().addWidget(help_min_nr_samples)
         self.hdbscan_settings_container_min_nr.setVisible(False)
 
         # Run button


### PR DESCRIPTION
Question marks added near min_clusters_size and min_nr_samples, which display short descriptions when hovered with a mouse and also redirect to a page with more info when clicked.
![image](https://user-images.githubusercontent.com/52177660/145459124-de30878a-e0c2-4536-9356-3049b5ce6605.png)

@Cryaaa, any ideas near which variables such feature would also be useful? I thought for kmeans parameters it's pretty self-explanatory so I didn't put them there.
