### PR TITLE
ignore "index" columns in dimensionality reduction and clustering

### DIFF
--- a/napari_clusters_plotter/_clustering.py
+++ b/napari_clusters_plotter/_clustering.py
@@ -307,7 +307,7 @@ class ClusteringWidget(QWidget):
             if features is not None:
                 self.properties_list.clear()
                 for p in list(features.keys()):
-                    if "label" in p or "CLUSTER_ID" in p:
+                    if "label" in p or "CLUSTER_ID" in p or "index" in p:
                         continue
                     item = QListWidgetItem(p)
                     self.properties_list.addItem(item)

--- a/napari_clusters_plotter/_dimensionality_reduction.py
+++ b/napari_clusters_plotter/_dimensionality_reduction.py
@@ -356,7 +356,7 @@ class DimensionalityReductionWidget(QWidget):
             if features is not None:
                 self.properties_list.clear()
                 for p in list(features.keys()):
-                    if "label" in p or "CLUSTER_ID" in p or "UMAP" in p or "t-SNE" in p:
+                    if "label" in p or "CLUSTER_ID" in p or "UMAP" in p or "t-SNE" in p or "index" in p:
                         continue
                     item = QListWidgetItem(p)
                     self.properties_list.addItem(item)


### PR DESCRIPTION
Hi Laura @lazigu ,

this PR suggest to ignore the "index" column in properties/features just like the "label" column. The background is the bug we discussed recently: The status bar of napari only shows the right measurements if there is an "index" column and that's why napari-skimage-regionprops now adds this column,

See also:
* https://github.com/napari/napari/issues/4250
* https://github.com/napari/napari/issues/2596
* https://github.com/haesleinhuepf/napari-skimage-regionprops/pull/18

Let me know if you see any issue with ingoring "index" columns.

Best,
Robert