### PR TITLE
Fix nans in measurements list

### DIFF
--- a/napari_clusters_plotter/_clustering.py
+++ b/napari_clusters_plotter/_clustering.py
@@ -322,58 +322,69 @@ class ClusteringWidget(QWidget):
         self.labels_select.reset_choices(event)
 
     # this function runs after the run button is clicked
-    def run(
-        self,
-        labels_layer: Labels,
-        selected_measurements_list: list,
-        selected_method: str,
-        num_clusters: int,
-        num_iterations: int,
-        standardize: bool,
-        min_cluster_size: int,
-        min_nr_samples: int,
-    ):
-        print("Selected labels layer: " + str(labels_layer))
-        print("Selected measurements: " + str(selected_measurements_list))
-        print("Selected clustering method: " + str(selected_method))
+    def run(self, labels_layer: Labels,
+            selected_measurements_list: list,
+            selected_method: str,
+            **kwargs):
 
-        features = get_layer_tabular_data(labels_layer)
-
-        # only select the columns the user requested and remove NaNs
-        selected_properties = features[selected_measurements_list]
-        non_nan_entries = features.dropna().index
-        non_nan_labels = features['label'].iloc[non_nan_entries]
-
-        # perform clustering
-        if selected_method == "KMeans":
-            y_pred = kmeans_clustering(
-                standardize, selected_properties, num_clusters, num_iterations
-            )
-            print("KMeans predictions finished.")
-
-        elif selected_method == "HDBSCAN":
-            y_pred = hdbscan_clustering(
-                standardize, selected_properties, min_cluster_size, min_nr_samples
-            )
-            print("HDBSCAN predictions finished.")
-        else:
-            warnings.warn(
-                "Clustering unsuccessful. Please re-check selected options."
-            )
-            return
-
-        # write result back to features/properties of the labels layer
-        df_clusters = pd.DataFrame(non_nan_labels, columns = ['label'])
-        df_clusters[
-            f"{selected_method}_CLUSTER_ID_SCALER_{str(standardize)}"
-            ] = y_pred
-
-        add_column_to_layer_tabular_data(labels_layer, y_pred)
+        run_clustering(labels_layer=labels_layer,
+                       selected_measurements_list=selected_measurements_list,
+                       selected_method=selected_method,
+                       **kwargs)
 
         # show region properties table as a new widget
         from ._utilities import show_table
 
         show_table(self.viewer, labels_layer)
+
+def run_clustering(labels_layer: Labels,
+                   selected_measurements_list: list,
+                   selected_method: str,
+                   num_clusters: int = 2,
+                   num_iterations: int = 100,
+                   standardize: bool = True,
+                   min_cluster_size: int = 5,
+                   min_nr_samples: int = 5):
+
+    print("Selected labels layer: " + str(labels_layer))
+    print("Selected measurements: " + str(selected_measurements_list))
+    print("Selected clustering method: " + str(selected_method))
+
+    features = get_layer_tabular_data(labels_layer)
+
+    # only select the columns the user requested and remove NaNs
+    selected_properties = features[selected_measurements_list]
+    non_nan_entries = features.index  # take all entries here
+    non_nan_labels = features['label'].iloc[non_nan_entries]
+
+    # perform clustering
+    if selected_method == "KMeans":
+        y_pred = kmeans_clustering(
+            standardize, selected_properties.iloc[non_nan_entries],
+            num_clusters, num_iterations
+        )
+        print("KMeans predictions finished.")
+
+    elif selected_method == "HDBSCAN":
+        y_pred = hdbscan_clustering(
+            standardize, selected_properties.iloc[non_nan_entries],
+            min_cluster_size, min_nr_samples
+        )
+        print("HDBSCAN predictions finished.")
+    else:
+        warnings.warn(
+            "Clustering unsuccessful. Please re-check selected options."
+        )
+        return
+
+    # write result back to features/properties of the labels layer
+    df_clusters = pd.DataFrame(non_nan_labels, columns = ['label'])
+    df_clusters[
+        f"{selected_method}_CLUSTER_ID_SCALER_{str(standardize)}"
+        ] = y_pred
+
+    add_column_to_layer_tabular_data(labels_layer, df_clusters)
+
 
 
 def kmeans_clustering(standardize, measurements, cluster_number, iterations):

--- a/napari_clusters_plotter/_clustering.py
+++ b/napari_clusters_plotter/_clustering.py
@@ -364,7 +364,8 @@ def run_clustering(labels_layer: Labels,
         Number of iterations for clustering procedure Only applicable to PCA.
         The default is 100.
     standardize : bool, optional
-        Whether to standardize features. The default is True.
+        Whether to standardize the data with z-score normalization. The default
+        is True.
     min_cluster_size : int, optional
         Minimal amount of data points to constitute a cluster. Only applicable
         to HDBSCAN. The default is 5.

--- a/napari_clusters_plotter/_clustering.py
+++ b/napari_clusters_plotter/_clustering.py
@@ -324,14 +324,14 @@ class ClusteringWidget(QWidget):
     # this function runs after the run button is clicked
     def run(
         self,
-        labels_layer,
-        selected_measurements_list,
-        selected_method,
-        num_clusters,
-        num_iterations,
-        standardize,
-        min_cluster_size,
-        min_nr_samples,
+        labels_layer: Labels,
+        selected_measurements_list: list,
+        selected_method: str,
+        num_clusters: int,
+        num_iterations: int,
+        standardize: bool,
+        min_cluster_size: int,
+        min_nr_samples: int,
     ):
         print("Selected labels layer: " + str(labels_layer))
         print("Selected measurements: " + str(selected_measurements_list))
@@ -342,7 +342,7 @@ class ClusteringWidget(QWidget):
         # only select the columns the user requested and remove NaNs
         selected_properties = features[selected_measurements_list]
         non_nan_entries = features.dropna().index
-        non_nan_labels = selected_properties['label'].iloc[non_nan_entries]
+        non_nan_labels = features['label'].iloc[non_nan_entries]
 
         # perform clustering
         if selected_method == "KMeans":

--- a/napari_clusters_plotter/_clustering.py
+++ b/napari_clusters_plotter/_clustering.py
@@ -345,7 +345,42 @@ def run_clustering(labels_layer: Labels,
                    standardize: bool = True,
                    min_cluster_size: int = 5,
                    min_nr_samples: int = 5):
+    """
+    Run selected clustering algorithm on data stored in a layer.properties dict.
 
+    Parameters
+    ----------
+    labels_layer : Labels
+        labels_layer with attribute `properties` or `features`
+    selected_measurements_list : list
+        list of features that should be included for the clustering. Must be
+        list of strings (e.g., `['measurement_1', 'measurement_2', ...]`).
+    selected_method : str
+        Selected clustering method. Can be either of ['KMEANS', 'HDBSCAN'].
+    num_clusters : int, optional
+        Number of clusters to be detected. Only applicable to PCA clustering.
+        The default is 2.
+    num_iterations : int, optional
+        Number of iterations for clustering procedure Only applicable to PCA.
+        The default is 100.
+    standardize : bool, optional
+        Whether to standardize features. The default is True.
+    min_cluster_size : int, optional
+        Minimal amount of data points to constitute a cluster. Only applicable
+        to HDBSCAN. The default is 5.
+    min_nr_samples : int, optional
+        Measure of how conservative the algorithm should decide on whether to
+        add a data point to a cluster or not. The default is 5.
+
+    Returns
+    -------
+    None.
+
+    See also
+    --------
+    https://hdbscan.readthedocs.io/en/latest/index.html
+    https://scikit-learn.org/stable/modules/generated/sklearn.cluster.KMeans.html
+    """
     print("Selected labels layer: " + str(labels_layer))
     print("Selected measurements: " + str(selected_measurements_list))
     print("Selected clustering method: " + str(selected_method))

--- a/napari_clusters_plotter/_dimensionality_reduction.py
+++ b/napari_clusters_plotter/_dimensionality_reduction.py
@@ -465,7 +465,7 @@ def run_dimensionality_reduction(
     # Create Dataframe with correct label entries
     df_embedding = pd.DataFrame(non_nan_labels, columns = ['label'])
     df_embedding[
-        [f'{selected_algorithm}_{i}' for i in range(pca_components)]
+        [f'{selected_algorithm}_{i}' for i in range(embedding.shape[1])]
         ] = embedding
 
     # write result back to properties

--- a/napari_clusters_plotter/_dimensionality_reduction.py
+++ b/napari_clusters_plotter/_dimensionality_reduction.py
@@ -374,25 +374,15 @@ class DimensionalityReductionWidget(QWidget):
         self,
         labels_layer: Labels,
         selected_measurements_list: list,
-        n_neighbours: int,
-        perplexity: float,
         selected_algorithm: str,
-        standardize: bool,
-        explained_variance: float,
-        pca_components: int,
-        n_components: int = 2):
+        **kwargs):
 
-        # Run dimensionality reduction
+        # Call external clustering function and pass all keyword arguments
         run_dimensionality_reduction(
             labels_layer=labels_layer,
             selected_measurements_list=selected_measurements_list,
-            n_neighbours=n_neighbours,
-            perplexity=perplexity,
             selected_algorithm=selected_algorithm,
-            standardize=standardize,
-            explained_variance=explained_variance,
-            pca_components=pca_components,
-            n_components=n_components)
+            **kwargs)
 
         from ._utilities import show_table
         show_table(self.viewer, labels_layer)
@@ -401,13 +391,58 @@ class DimensionalityReductionWidget(QWidget):
 def run_dimensionality_reduction(
         labels_layer: Labels,
         selected_measurements_list: list,
-        n_neighbours: int,
-        perplexity: float,
         selected_algorithm: str,
-        standardize: bool,
-        explained_variance: float,
-        pca_components: int,
+        n_neighbours: int = DEFAULTS['n_neighbors'],
+        perplexity: float = DEFAULTS['perplexity'],
+        standardize: bool = DEFAULTS['standardization'],
+        explained_variance: float = DEFAULTS['explained_variance'],
+        pca_components: int = DEFAULTS['pca_components'],
         n_components: int = 2):
+    f"""
+    Run dimensionality reduction algorithm on data stored in layer.properties.
+
+    Parameters
+    ----------
+    labels_layer : Labels
+        Labels layer with measurements stored in layer.properties or
+        layer.features
+    selected_measurements_list : list
+        List of measurements that should be included for the dimensionality
+        reduction. Must be list of strings (e.g.,
+        `['measurement_1', 'measurement_2', ...]`).
+    selected_algorithm : str
+        Dimensionality reduction algorithm to use. Can be either of
+        `['PCA', 'UMAP', 't-SNE']`
+    n_neighbours : int, optional
+        Number of neighbors to consider for dimensionality reduction.
+        Only applicable to UMAP. The default is {DEFAULTS['n_neighbors']}.
+    perplexity : float, optional
+        Determines a degree of separation between similar and different data
+        points. Only applicable to t-SNE. The default is {DEFAULTS['perplexity']}.
+    standardize : bool, optional
+        Whether to standardize the data with z-score normalization.
+        The default is {DEFAULTS['standardization']}.
+    explained_variance : float, optional
+        The amount of variance explained by each of the selected components.
+        Only applicable to PCA. The default is {DEFAULTS['explained_variance']}.
+    pca_components : int, optional
+        The number of dimensions of the reduced feature space.
+        Only applicable for PCA. The default is {DEFAULTS['pca_components']}.
+    n_components : int, optional
+        The number of dimensions of the reduced feature space.
+        Only applicable to UMAP and t-SNE. The default is 2.
+
+    Returns
+    -------
+    None.
+
+    See also
+    --------
+    https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.StandardScaler.html
+    https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html
+    https://scikit-learn.org/stable/modules/generated/sklearn.manifold.TSNE.html
+    https://pypi.org/project/umap-learn/
+    """
     print("Selected labels layer: " + str(labels_layer))
     print("Selected measurements: " + str(selected_measurements_list))
 

--- a/napari_clusters_plotter/_dimensionality_reduction.py
+++ b/napari_clusters_plotter/_dimensionality_reduction.py
@@ -416,7 +416,7 @@ def run_dimensionality_reduction(
     # only select the columns the user requested and drop NaNs
     properties_to_reduce = features[selected_measurements_list]
     non_nan_entries = features.dropna().index
-    non_nan_labels = properties_to_reduce['label'].iloc[non_nan_entries]
+    non_nan_labels = features['label'].iloc[non_nan_entries]
 
     if selected_algorithm == "UMAP":
         print(

--- a/napari_clusters_plotter/_tests/test_clustering.py
+++ b/napari_clusters_plotter/_tests/test_clustering.py
@@ -24,6 +24,7 @@ def test_clustering_bad_data(make_napari_viewer):
     from napari_clusters_plotter._clustering import ClusteringWidget
     from napari_clusters_plotter._measure import get_regprops_from_regprops_source
     from napari_clusters_plotter._utilities import set_features
+    from napari_clusters_plotter._dimensionality_reduction import run_dimensionality_reduction
 
     label = np.array(
         [
@@ -44,16 +45,29 @@ def test_clustering_bad_data(make_napari_viewer):
     measurements = get_regprops_from_regprops_source(image, label, 'shape + intensity')
     set_features(labels_layer, measurements)
 
-    widget.run(
-            labels_layer=labels_layer,
-            selected_measurements_list=list(measurements.keys()),
-            selected_method='KMEANS',
+    # Reduce dimensionality
+    run_dimensionality_reduction(
+        labels_layer=labels_layer,
+        selected_measurements_list=list(measurements.keys()),
+        n_neighbours=15,
+        perplexity=5,
+        selected_algorithm='UMAP',
+        standardize=True,
+        explained_variance=5,
+        pca_components=2,
+        n_components=2)
+
+    widget = ClusteringWidget(viewer)
+    widget.run(labels_layer=labels_layer,
+            selected_measurements_list = ['UMAP_0', 'UMAP_1'],
+            selected_method='HDBSCAN',
             num_clusters=2,
-            num_iterations=2,
+            num_iterations=100,
             standardize=True,
-            min_cluster_size=1,
-            min_nr_samples=1,
-        )
+            min_cluster_size=2,
+            min_nr_samples=1)
+
+    assert 'HDBSCAN_CLUSTER_ID_SCALER_True' in list(labels_layer.properties.keys())
 
 def test_kmeans_clustering():
 

--- a/napari_clusters_plotter/_tests/test_clustering.py
+++ b/napari_clusters_plotter/_tests/test_clustering.py
@@ -19,6 +19,41 @@ def test_clustering_widget(make_napari_viewer):
     viewer.window.add_dock_widget(plot_widget)
     assert len(viewer.window._dock_widgets) == n_wdgts + 1
 
+def test_clustering_bad_data(make_napari_viewer):
+    viewer = make_napari_viewer()
+    from napari_clusters_plotter._clustering import ClusteringWidget
+    from napari_clusters_plotter._measure import get_regprops_from_regprops_source
+    from napari_clusters_plotter._utilities import set_features
+
+    label = np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 1, 0, 0, 2, 2],
+            [0, 0, 0, 0, 2, 2, 2],
+            [3, 3, 0, 0, 0, 0, 0],
+            [0, 0, 4, 4, 0, 0, 0],
+            [6, 6, 6, 6, 0, 5, 0],  # <-single pixel label
+            [0, 7, 7, 0, 0, 0, 0],
+        ]
+    )
+
+    image = np.random.random((label.shape))
+    labels_layer = viewer.add_labels(label)
+
+    widget = ClusteringWidget(viewer)
+    measurements = get_regprops_from_regprops_source(image, label, 'shape + intensity')
+    set_features(labels_layer, measurements)
+
+    widget.run(
+            labels_layer=labels_layer,
+            selected_measurements_list=list(measurements.keys()),
+            selected_method='KMEANS',
+            num_clusters=2,
+            num_iterations=2,
+            standardize=True,
+            min_cluster_size=1,
+            min_nr_samples=1,
+        )
 
 def test_kmeans_clustering():
 
@@ -103,5 +138,5 @@ def test_hdbscan_clustering():
 
 
 if __name__ == "__main__":
-    test_kmeans_clustering()
-    test_hdbscan_clustering()
+    import napari
+    test_clustering_bad_data(napari.Viewer)

--- a/napari_clusters_plotter/_tests/test_dimension_reduction.py
+++ b/napari_clusters_plotter/_tests/test_dimension_reduction.py
@@ -101,7 +101,7 @@ def test_call_to_function(make_napari_viewer):
     )
 
     result = get_layer_tabular_data(label_layer)
-    assert "PC_0" in result.columns
+    assert "PCA_0" in result.columns
 
 def test_bad_measurements(make_napari_viewer):
 
@@ -142,6 +142,7 @@ def test_bad_measurements(make_napari_viewer):
                 5, 3, 'UMAP', True, 10, 2, 2)
     _widget.run(labels_layer, list(labels_layer.properties.keys()),
                 5, 3, 't-SNE', True, 10, 2, 2)
+
 
 def test_umap():
 
@@ -187,4 +188,4 @@ def test_pca():
 
 if __name__ == "__main__":
     import napari
-    test_bad_measurements(napari.Viewer)
+    test_call_to_function(napari.Viewer)

--- a/napari_clusters_plotter/_tests/test_dimension_reduction.py
+++ b/napari_clusters_plotter/_tests/test_dimension_reduction.py
@@ -121,8 +121,6 @@ def test_bad_measurements(make_napari_viewer):
     )
 
     image = np.random.random((label.shape))
-
-    img_layer = viewer.add_image(image)
     labels_layer = viewer.add_labels(label)
 
     for widget in widget_list:
@@ -140,9 +138,10 @@ def test_bad_measurements(make_napari_viewer):
 
     _widget.run(labels_layer, list(labels_layer.properties.keys()),
                 5, 3, 'PCA', True, 10, 2, 2)
-
-
-
+    _widget.run(labels_layer, list(labels_layer.properties.keys()),
+                5, 3, 'UMAP', True, 10, 2, 2)
+    _widget.run(labels_layer, list(labels_layer.properties.keys()),
+                5, 3, 't-SNE', True, 10, 2, 2)
 
 def test_umap():
 

--- a/napari_clusters_plotter/_tests/test_measurements.py
+++ b/napari_clusters_plotter/_tests/test_measurements.py
@@ -1,5 +1,4 @@
-# import numpy as np
-
+import numpy as np
 import napari_clusters_plotter as ncp
 
 
@@ -8,22 +7,19 @@ def test_measurements(make_napari_viewer):
     viewer = make_napari_viewer()
     widget_list = ncp.napari_experimental_provide_dock_widget()
 
-    # label = np.array(
-    #     [
-    #         [0, 0, 0, 0, 0, 0, 0],
-    #         [0, 1, 1, 0, 0, 2, 2],
-    #         [0, 0, 0, 0, 2, 2, 2],
-    #         [3, 3, 0, 0, 0, 0, 0],
-    #         [0, 0, 4, 4, 0, 5, 5],
-    #         [6, 6, 6, 6, 0, 5, 0],
-    #         [0, 7, 7, 0, 0, 0, 0],
-    #     ]
-    # )
+    label = np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 1, 0, 0, 2, 2],
+            [0, 0, 0, 0, 2, 2, 2],
+            [3, 3, 0, 0, 0, 0, 0],
+            [0, 0, 4, 4, 0, 0, 0],
+            [6, 6, 6, 6, 0, 5, 0],  # <-single pixel label
+            [0, 7, 7, 0, 0, 0, 0],
+        ]
+    )
 
-    # image = label * 1.5
-
-    # label_layer = viewer.add_labels(label)
-    # image_layer = viewer.add_image(image)
+    image = np.random.random((label.shape))
 
     for widget in widget_list:
         _widget = widget(viewer)
@@ -31,34 +27,14 @@ def test_measurements(make_napari_viewer):
             break
 
     viewer.window.add_dock_widget(_widget)
-    """"
-    _widget.run(image_layer, label_layer, "Measure now intensity", None, None)
-    data = label_layer.features
-    assert "max_intensity" in data.columns
-    assert "sum_intensity" in data.columns
-    assert "mean_intensity" in data.columns
-    assert "min_intensity" in data.columns
 
-    assert data["max_intensity"].max() == 7 * 1.5
+    from napari_clusters_plotter._measure import get_regprops_from_regprops_source
 
-    _widget.run(image_layer, label_layer, "Measure now shape", None, None)
-    data = label_layer.features
-    assert "area" in data.columns
-    assert "mean_distance_to_centroid" in data.columns
-    assert "max_distance_to_centroid" in data.columns
-    assert "mean_max_distance_to_centroid_ratio" in data.columns
+    measurements = get_regprops_from_regprops_source(image, label, 'shape')
+    measurements = get_regprops_from_regprops_source(image, label, 'intensity')
+    measurements = get_regprops_from_regprops_source(image, label, 'shape + intensity')
+    measurements = get_regprops_from_regprops_source(image, label, 'neigborhood')
 
-    assert data["area"].max() == 5
-
-    _widget.run(image_layer, label_layer, "Measure now neighborhood", None, "2, 3, 4")
-    data = label_layer.features
-    assert "avg distance of 2 closest points" in data.columns
-    assert "avg distance of 3 closest points" in data.columns
-    assert "avg distance of 4 closest points" in data.columns
-    assert "touching neighbor count" in data.columns
-    assert data["touching neighbor count"].loc[5] == 2
-    """
-
-
-if __name__ == "__main__":
-    test_measurements()
+if __name__ == '__main__':
+    import napari
+    test_measurements(napari.Viewer)

--- a/napari_clusters_plotter/_tests/test_utils.py
+++ b/napari_clusters_plotter/_tests/test_utils.py
@@ -31,15 +31,22 @@ def test_feature_setting(make_napari_viewer):
     some_features = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
     set_features(label_layer, some_features)
 
-    assert isinstance(label_layer.features, pd.DataFrame)
+    features = get_layer_tabular_data(label_layer)
+
+    assert isinstance(features, pd.DataFrame)
+    assert features.equals(some_features)
 
     some_features = get_layer_tabular_data(label_layer)
     assert isinstance(some_features, pd.DataFrame)
 
-    add_column_to_layer_tabular_data(label_layer, "C", [5, 6, 7])
+    new_data = pd.DataFrame(columns=['A', 'C'])
+    new_data['A'] = some_features['A']
+    new_data['C'] = [3, 4, 7]
+    add_column_to_layer_tabular_data(label_layer, new_data, on='A')
     some_features = get_layer_tabular_data(label_layer)
     assert "C" in some_features.columns
 
 
 if __name__ == "__main__":
-    test_feature_setting()
+    import napari
+    test_feature_setting(napari.Viewer)

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -32,12 +32,12 @@ def get_layer_tabular_data(layer):
     return None
 
 
-def add_column_to_layer_tabular_data(layer, data):
+def add_column_to_layer_tabular_data(layer, data, on='label'):
     if hasattr(layer, "properties"):
-        df = pd.DataFrame(layer.properties).merge(data, how='outer', on='label')
+        df = pd.DataFrame(layer.properties).merge(data, how='outer', on=on)
         layer.properties = df.to_dict(orient='list')
     if hasattr(layer, "features"):
-        layer.features.merge(data, how='outer', on='label')
+        layer.features.merge(data, how='outer', on=on)
 
 
 def get_nice_colormap():

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -32,11 +32,12 @@ def get_layer_tabular_data(layer):
     return None
 
 
-def add_column_to_layer_tabular_data(layer, column_name, data):
+def add_column_to_layer_tabular_data(layer, data):
     if hasattr(layer, "properties"):
-        layer.properties[column_name] = data
+        df = pd.DataFrame(layer.properties).merge(data, how='outer', on='label')
+        layer.properties = df.to_dict(orient='list')
     if hasattr(layer, "features"):
-        layer.features[column_name] = data
+        layer.features.merge(data, how='outer', on='label')
 
 
 def get_nice_colormap():


### PR DESCRIPTION
Closes #56 

## Major changes:
- The dimensionality reduction plugin now only takes rows from the measurements values that have no NaNs. This is done with the pandas `DataFrame.dropna()` command. At the same time, the information about which labels are included for this is stored. 
- The `add_column_to_layer_tabular_data()` is changed to handle this. It now receives a target layer into which the new data should be appended and a new dataframe that should be added. The new dataframe must have one column in common with the already available tabular data. In this case, this is the `labels` column. The new values are then sorted into `layer.properties` into the correct rows; the rows with no data from the dimensionality reduction will have a `NaN` entry.
- The clustering procedure has been changed to support appending the cluster index to the data. However, replacing the `NaN` values is not necessary here as the implemented algorithms (kmeans and hdbscan) can apparently handle `NaN` and will give these data points the cluster index `-1`.

## Code style changes
- I moved the dimensionality reduction and the clustering functions out of the widget. Thus, they can be tested easier.
- I added type annotations and default values to the clustering/dimensionality reduction functions as well as default arguments.
- I added docstrings for the clustering functions which could make it easier in the future to also use these functions from code.