### PR TITLE
Add clustering methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,6 @@ visualization in the image, turn off the visibility of the analysed labels layer
 
 ![](https://github.com/BiAPoL/napari-clusters-plotter/raw/main/images/plot_interactive.png)
 
-Hold down the SHIFT key while annotating regions in the plot to manually select multiple clusters.
-
-![](https://github.com/BiAPoL/napari-clusters-plotter/raw/main/images/multi-select-manual-clustering.gif)
-
 You can also select a labeled object in the original labels layer (not "cluster_ids_in_space" layer) using the `Pick`
 mode in napari and see which data point in the plot it corresponds to.
 

--- a/README.md
+++ b/README.md
@@ -87,10 +87,14 @@ need to save them for usage in other widgets unless you wish to do so.
 
 Afterwards, you can again save and/or close the table. Also, close the Dimensionality Reduction widget.
 
-### Clustering: k-means or HDBSCAN
-If manual clustering, as shown above, is not an option, you can automatically cluster your data, e.g. using the
-[k-means clustering algorithm](https://towardsdatascience.com/k-means-clustering-algorithm-applications-evaluation-methods-and-drawbacks-aa03e644b48a)
-or [HDBSCAN](https://hdbscan.readthedocs.io/en/latest/how_hdbscan_works.html).
+### Clustering
+If manual clustering, as shown above, is not an option, you can automatically cluster your data, using these implemented algorithms:
+* [k-means clustering (KMEANS)](https://towardsdatascience.com/k-means-clustering-algorithm-applications-evaluation-methods-and-drawbacks-aa03e644b48a)
+* [Hierarchical Density-Based Spatial Clustering of Applications with Noise (HDBSCAN)](https://hdbscan.readthedocs.io/en/latest/how_hdbscan_works.html)
+* [Gaussian Mixture Model (GMM)](https://scikit-learn.org/stable/modules/mixture.html)
+* [Mean Shift (MS)](https://scikit-learn.org/stable/auto_examples/cluster/plot_mean_shift.html#sphx-glr-auto-examples-cluster-plot-mean-shift-py)
+* [Agglomerative clustering (AC)](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.AgglomerativeClustering.html)
+
 Therefore, click the menu `Tools > Measurement > Clustering (ncp)`,
 again, select the analysed labels layer.
 This time select the measurements for clustering, e.g. select _only_ the `UMAP` measurements.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ visualization in the image, turn off the visibility of the analysed labels layer
 
 ![](https://github.com/BiAPoL/napari-clusters-plotter/raw/main/images/plot_interactive.png)
 
+Hold down the SHIFT key while annotating regions in the plot to manually select multiple clusters.
+
+![](https://github.com/BiAPoL/napari-clusters-plotter/raw/main/images/multi-select-manual-clustering.gif)
+
 You can also select a labeled object in the original labels layer (not "cluster_ids_in_space" layer) using the `Pick`
 mode in napari and see which data point in the plot it corresponds to.
 

--- a/napari_clusters_plotter/_clustering.py
+++ b/napari_clusters_plotter/_clustering.py
@@ -500,7 +500,7 @@ class ClusteringWidget(QWidget):
             print("KMeans predictions finished.")
             # write result back to features/properties of the labels layer
             add_column_to_layer_tabular_data(
-                labels_layer, "KMEANS_CLUSTER_ID_SCALER_" + str(standardize), y_pred
+                labels_layer, "KMEANS_CLUSTER_ID", y_pred
             )
 
         elif selected_method == "HDBSCAN":
@@ -510,7 +510,7 @@ class ClusteringWidget(QWidget):
             print("HDBSCAN predictions finished.")
             # write result back to features/properties of the labels layer
             add_column_to_layer_tabular_data(
-                labels_layer, "HDBSCAN_CLUSTER_ID_SCALER_" + str(standardize), y_pred
+                labels_layer, "HDBSCAN_CLUSTER_ID", y_pred
             )
         elif selected_method == "Gaussian Mixture Model (GMM)":
             y_pred = gaussian_mixture_model(
@@ -519,7 +519,7 @@ class ClusteringWidget(QWidget):
             print("Gaussian Mixture Model predictions finished.")
             # write result back to features/properties of the labels layer
             add_column_to_layer_tabular_data(
-                labels_layer, "GMM_CLUSTER_ID_SCALER_" + str(standardize), y_pred
+                labels_layer, "GMM_CLUSTER_ID", y_pred
             )
         elif selected_method == "Mean Shift (MS)":
             y_pred = mean_shift(
@@ -528,7 +528,7 @@ class ClusteringWidget(QWidget):
             print("Mean Shift predictions finished.")
             # write result back to features/properties of the labels layer
             add_column_to_layer_tabular_data(
-                labels_layer, "MS_CLUSTER_ID_SCALER_" + str(standardize), y_pred
+                labels_layer, "MS_CLUSTER_ID", y_pred
             )
         elif selected_method == "Agglomerative Clustering (AC)":
             y_pred = agglomerative_clustering(
@@ -537,7 +537,7 @@ class ClusteringWidget(QWidget):
             print("Agglomerative Clustering predictions finished.")
             # write result back to features/properties of the labels layer
             add_column_to_layer_tabular_data(
-                labels_layer, "AC_CLUSTER_ID_SCALER_" + str(standardize), y_pred
+                labels_layer, "AC_CLUSTER_ID", y_pred
             )
         else:
             warnings.warn(
@@ -599,8 +599,6 @@ def agglomerative_clustering(measurements, cluster_number, n_neighbors):
 
 def hdbscan_clustering(measurements, min_cluster_size, min_samples):
     import hdbscan
-
-    print("HDBSCAN predictions started (standardize: " + str(standardize) + ")...")
 
     clustering_hdbscan = hdbscan.HDBSCAN(
         min_cluster_size=min_cluster_size, min_samples=min_samples

--- a/napari_clusters_plotter/_clustering.py
+++ b/napari_clusters_plotter/_clustering.py
@@ -280,6 +280,7 @@ class ClusteringWidget(QWidget):
                 self.standardization.value,
                 self.hdbscan_min_clusters_size.value,
                 self.hdbscan_min_nr_samples.value,
+                self.gmm_settings_container_nr.value
             )
 
         run_button.clicked.connect(run_clicked)
@@ -362,6 +363,7 @@ class ClusteringWidget(QWidget):
         standardize,
         min_cluster_size,
         min_nr_samples,
+        gmm_num_cluster
     ):
         print("Selected labels layer: " + str(labels_layer))
         print("Selected measurements: " + str(selected_measurements_list))
@@ -394,7 +396,7 @@ class ClusteringWidget(QWidget):
             )
         elif selected_method == "Gaussian Mixture Model (GMM)":
             y_pred = gaussian_mixture_model(
-                standardize, selected_properties, num_clusters
+                standardize, selected_properties, gmm_num_cluster
             )
             print("Gaussian Mixture Model predictions finished.")
             # write result back to features/properties of the labels layer

--- a/napari_clusters_plotter/_clustering.py
+++ b/napari_clusters_plotter/_clustering.py
@@ -512,7 +512,7 @@ class ClusteringWidget(QWidget):
             add_column_to_layer_tabular_data(labels_layer, "AC_CLUSTER_ID", y_pred)
         else:
             warnings.warn(
-                "Clustering unsuccessful. Please check again selected options."
+                "Clustering unsuccessful. Please check selected options again."
             )
             return
 

--- a/napari_clusters_plotter/_clustering.py
+++ b/napari_clusters_plotter/_clustering.py
@@ -33,8 +33,8 @@ DEFAULTS = {
     "gmm_nr_clusters": 2,
     "ms_quantile": 0.2,
     "ms_n_samples": 50,
-    "ac_nr_clusters": 2,
-    "ac_nr_neighbors": 2,
+    "ac_n_clusters": 2,
+    "ac_n_neighbors": 2,
 }
 
 
@@ -183,8 +183,8 @@ class ClusteringWidget(QWidget):
         )
         self.ac_n_clusters = create_widget(
             widget_type="SpinBox",
-            name="ac_nr_clusters",
-            value=DEFAULTS["ac_nr_clusters"],
+            name="ac_n_clusters",
+            value=DEFAULTS["ac_n_clusters"],
             options={"min": 2, "step": 1},
         )
 
@@ -201,8 +201,8 @@ class ClusteringWidget(QWidget):
         )
         self.ac_n_neighbors = create_widget(
             widget_type="SpinBox",
-            name="ac_nr_neighbors",
-            value=DEFAULTS["ac_nr_neighbors"],
+            name="ac_n_neighbors",
+            value=DEFAULTS["ac_n_neighbors"],
             options={"min": 2, "step": 1},
         )
 

--- a/napari_clusters_plotter/_clustering.py
+++ b/napari_clusters_plotter/_clustering.py
@@ -33,6 +33,8 @@ DEFAULTS = {
     "gmm_nr_clusters": 2,
     "ms_quantile": 0.2, 
     "ms_n_samples": 50,
+    "ac_nr_clusters":2,
+    "ac_nr_neighbors":2,
 }
 
 
@@ -44,6 +46,7 @@ class ClusteringWidget(QWidget):
         HDBSCAN = "HDBSCAN"
         GMM = "Gaussian Mixture Model (GMM)"
         MS = "Mean Shift (MS)"
+        AC = "Agglomerative Clustering (AC)"
 
     def __init__(self, napari_viewer):
         super().__init__()
@@ -180,6 +183,46 @@ class ClusteringWidget(QWidget):
         )
         self.ms_settings_container_samples.setVisible(False)
 
+        #
+        # clustering options for Agglomerative Clustering
+        # selection of number of clusters
+        self.ac_settings_container_clusters = QWidget()
+        self.ac_settings_container_clusters.setLayout(QHBoxLayout())
+        self.ac_settings_container_clusters.layout().addWidget(
+            QLabel("Number of clusters")
+        )
+        self.ac_n_clusters = create_widget(
+            widget_type="SpinBox",
+            name="ac_nr_clusters",
+            value=DEFAULTS["ac_nr_clusters"],
+            options={"min": 2, "step": 1},
+        )
+
+        self.ac_settings_container_clusters.layout().addWidget(
+            self.ac_n_clusters.native
+        )
+        self.ac_settings_container_clusters.setVisible(False)
+
+
+        # selection of number of clusters
+        self.ac_settings_container_neighbors = QWidget()
+        self.ac_settings_container_neighbors.setLayout(QHBoxLayout())
+        self.ac_settings_container_neighbors.layout().addWidget(
+            QLabel("Number of neighbors")
+        )
+        self.ac_n_neighbors = create_widget(
+            widget_type="SpinBox",
+            name="ac_nr_neighbors",
+            value=DEFAULTS["ac_nr_neighbors"],
+            options={"min": 2, "step": 1},
+        )
+
+        self.ac_settings_container_neighbors.layout().addWidget(
+            self.ac_n_neighbors.native
+        )
+        self.ac_settings_container_neighbors.setVisible(False)
+
+
         # checkbox whether data should be standardized
         self.clustering_settings_container_scaler = QWidget()
         self.clustering_settings_container_scaler.setLayout(QHBoxLayout())
@@ -293,6 +336,8 @@ class ClusteringWidget(QWidget):
         self.layout().addWidget(self.gmm_settings_container_nr)
         self.layout().addWidget(self.ms_settings_container_nr)
         self.layout().addWidget(self.ms_settings_container_samples)
+        self.layout().addWidget(self.ac_settings_container_clusters)
+        self.layout().addWidget(self.ac_settings_container_neighbors)
         self.layout().addWidget(self.clustering_settings_container_scaler)
         self.layout().addWidget(defaults_container)
         self.layout().addWidget(run_container)
@@ -323,7 +368,9 @@ class ClusteringWidget(QWidget):
                 self.hdbscan_min_nr_samples.value,
                 self.gmm_nr_clusters.value,
                 self.ms_quantile.value,
-                self.ms_n_samples.value
+                self.ms_n_samples.value,
+                self.ac_n_clusters.value,
+                self.ac_n_neighbors.value
             )
 
         run_button.clicked.connect(run_clicked)
@@ -368,6 +415,12 @@ class ClusteringWidget(QWidget):
             active=self.clust_method_choice_list.current_choice
             == self.Options.MS.value,
         )
+        widgets_inactive(
+            self.ac_settings_container_clusters,
+            self.ac_settings_container_neighbors,
+            active=self.clust_method_choice_list.current_choice
+            == self.Options.AC.value,
+        )
 
 
 
@@ -382,6 +435,8 @@ class ClusteringWidget(QWidget):
                 == self.Options.GMM.value
                 or self.clust_method_choice_list.current_choice
                 == self.Options.MS.value
+                or self.clust_method_choice_list.current_choice
+                == self.Options.AC.value
             ),
         )
 
@@ -419,7 +474,9 @@ class ClusteringWidget(QWidget):
         min_nr_samples,
         gmm_num_cluster,
         ms_quantile, 
-        ms_n_samples
+        ms_n_samples,
+        ac_n_clusters,
+        ac_n_neighbors
     ):
         print("Selected labels layer: " + str(labels_layer))
         print("Selected measurements: " + str(selected_measurements_list))
@@ -430,10 +487,15 @@ class ClusteringWidget(QWidget):
         # only select the columns the user requested
         selected_properties = features[selected_measurements_list]
 
+        # perform standard scaling, if selected
+        if standardize:
+            from sklearn.preprocessing import StandardScaler
+            selected_properties = StandardScaler().fit_transform(selected_properties)
+
         # perform clustering
         if selected_method == "KMeans":
             y_pred = kmeans_clustering(
-                standardize, selected_properties, num_clusters, num_iterations
+                selected_properties, num_clusters, num_iterations
             )
             print("KMeans predictions finished.")
             # write result back to features/properties of the labels layer
@@ -443,7 +505,7 @@ class ClusteringWidget(QWidget):
 
         elif selected_method == "HDBSCAN":
             y_pred = hdbscan_clustering(
-                standardize, selected_properties, min_cluster_size, min_nr_samples
+                selected_properties, min_cluster_size, min_nr_samples
             )
             print("HDBSCAN predictions finished.")
             # write result back to features/properties of the labels layer
@@ -452,7 +514,7 @@ class ClusteringWidget(QWidget):
             )
         elif selected_method == "Gaussian Mixture Model (GMM)":
             y_pred = gaussian_mixture_model(
-                standardize, selected_properties, gmm_num_cluster
+                selected_properties, gmm_num_cluster
             )
             print("Gaussian Mixture Model predictions finished.")
             # write result back to features/properties of the labels layer
@@ -461,12 +523,21 @@ class ClusteringWidget(QWidget):
             )
         elif selected_method == "Mean Shift (MS)":
             y_pred = mean_shift(
-                standardize, selected_properties, ms_quantile, ms_n_samples
+                selected_properties, ms_quantile, ms_n_samples
             )
             print("Mean Shift predictions finished.")
             # write result back to features/properties of the labels layer
             add_column_to_layer_tabular_data(
                 labels_layer, "MS_CLUSTER_ID_SCALER_" + str(standardize), y_pred
+            )
+        elif selected_method == "Agglomerative Clustering (AC)":
+            y_pred = agglomerative_clustering(
+                selected_properties, ac_n_clusters, ac_n_neighbors
+            )
+            print("Agglomerative Clustering predictions finished.")
+            # write result back to features/properties of the labels layer
+            add_column_to_layer_tabular_data(
+                labels_layer, "AC_CLUSTER_ID_SCALER_" + str(standardize), y_pred
             )
         else:
             warnings.warn(
@@ -480,11 +551,9 @@ class ClusteringWidget(QWidget):
         show_table(self.viewer, labels_layer)
         
         
-def mean_shift(standardize, measurements, quantile=0.2, n_samples=50):
+def mean_shift(measurements, quantile=0.2, n_samples=50):
     from sklearn.cluster import MeanShift, estimate_bandwidth
 
-    if standardize:
-        measurements = standard_scale(measurements)
 
     bandwidth = estimate_bandwidth(measurements, quantile=quantile, n_samples=n_samples)
 
@@ -492,32 +561,43 @@ def mean_shift(standardize, measurements, quantile=0.2, n_samples=50):
     return ms.fit_predict(measurements)
 
 
-def gaussian_mixture_model(standardize, measurements, cluster_number):
+def gaussian_mixture_model(measurements, cluster_number):
     from sklearn import mixture
 
     # fit a Gaussian Mixture Model
     gmm = mixture.GaussianMixture(n_components=cluster_number, covariance_type='full')
 
-    if standardize:
-        measurements = standard_scale(measurements)
-
     return gmm.fit_predict(measurements)
 
 
-def kmeans_clustering(standardize, measurements, cluster_number, iterations):
+def kmeans_clustering(measurements, cluster_number, iterations):
     from sklearn.cluster import KMeans
 
-    print("KMeans predictions started (standardize: " + str(standardize) + ")...")
-
     km = KMeans(n_clusters=cluster_number, max_iter=iterations, random_state=1000)
-
-    if standardize:
-        measurements = standard_scale(measurements)
 
     return km.fit_predict(measurements)
 
 
-def hdbscan_clustering(standardize, measurements, min_cluster_size, min_samples):
+def agglomerative_clustering(measurements, cluster_number, n_neighbors):
+    from sklearn.cluster import AgglomerativeClustering
+    from sklearn.neighbors import kneighbors_graph
+
+    # source: https://scikit-learn.org/stable/auto_examples/cluster/plot_cluster_comparison.html
+    # connectivity matrix for structured Ward
+    connectivity = kneighbors_graph(
+        measurements, n_neighbors=n_neighbors, include_self=False
+    )
+    # make connectivity symmetric
+    connectivity = 0.5 * (connectivity + connectivity.T)
+
+    ac = AgglomerativeClustering(
+        n_clusters=cluster_number, linkage="ward", connectivity=connectivity
+    )
+
+    return ac.fit_predict(measurements)
+
+
+def hdbscan_clustering(measurements, min_cluster_size, min_samples):
     import hdbscan
 
     print("HDBSCAN predictions started (standardize: " + str(standardize) + ")...")
@@ -526,12 +606,4 @@ def hdbscan_clustering(standardize, measurements, min_cluster_size, min_samples)
         min_cluster_size=min_cluster_size, min_samples=min_samples
     )
 
-    if standardize:
-        measurements = standard_scale(measurements)
-
     return clustering_hdbscan.fit_predict(measurements)
-
-def standard_scale(data):
-    from sklearn.preprocessing import StandardScaler
-
-    return StandardScaler().fit_transform(data)

--- a/napari_clusters_plotter/_clustering.py
+++ b/napari_clusters_plotter/_clustering.py
@@ -381,14 +381,9 @@ def kmeans_clustering(standardize, measurements, cluster_number, iterations):
     km = KMeans(n_clusters=cluster_number, max_iter=iterations, random_state=1000)
 
     if standardize:
-        from sklearn.preprocessing import StandardScaler
-
-        scaled_measurements = StandardScaler().fit_transform(measurements)
-        # returning prediction as a list for generating clustering image
-        return km.fit_predict(scaled_measurements)
-
-    else:
-        return km.fit_predict(measurements)
+        measurements = standard_scale(measurements)
+        
+    return km.fit_predict(measurements)
 
 
 def hdbscan_clustering(standardize, measurements, min_cluster_size, min_samples):
@@ -401,11 +396,11 @@ def hdbscan_clustering(standardize, measurements, min_cluster_size, min_samples)
     )
 
     if standardize:
-        from sklearn.preprocessing import StandardScaler
+        measurements = standard_scale(measurements)
 
-        scaled_measurements = StandardScaler().fit_transform(measurements)
-        clustering_hdbscan.fit(scaled_measurements)
-        return clustering_hdbscan.fit_predict(scaled_measurements)
+    return clustering_hdbscan.fit_predict(measurements)
 
-    else:
-        return clustering_hdbscan.fit_predict(measurements)
+def standard_scale(data):
+    from sklearn.preprocessing import StandardScaler
+
+    return StandardScaler().fit_transform(measurements)

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -13,8 +13,8 @@ from matplotlib.widgets import LassoSelector, RectangleSelector
 from napari.layers import Labels
 from napari_tools_menu import register_dock_widget
 from qtpy import QtWidgets
-from qtpy.QtCore import QTimer
-from qtpy.QtGui import QIcon
+from qtpy.QtCore import QTimer, Qt
+from qtpy.QtGui import QIcon, QGuiApplication
 from qtpy.QtWidgets import (
     QComboBox,
     QHBoxLayout,
@@ -24,7 +24,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ._utilities import get_layer_tabular_data, get_nice_colormap
+from ._utilities import get_layer_tabular_data, get_nice_colormap, add_column_to_layer_tabular_data
 
 ICON_ROOT = PathL(__file__).parent / "icons"
 
@@ -236,7 +236,15 @@ class PlotterWidget(QWidget):
             clustering_ID = "MANUAL_CLUSTER_ID"
 
             features = get_layer_tabular_data(self.analysed_layer)
-            features[clustering_ID] = inside
+
+            modifiers = QGuiApplication.keyboardModifiers()
+            if modifiers == Qt.ShiftModifier and clustering_ID in features.keys():
+                former_clusters = features[clustering_ID]
+                former_clusters[inside] = np.max(former_clusters) + 1
+                features[clustering_ID] = former_clusters
+            else:
+                features[clustering_ID] = inside
+            add_column_to_layer_tabular_data(self.analysed_layer, clustering_ID, features[clustering_ID])
 
             # redraw the whole plot
             self.run(

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -13,8 +13,8 @@ from matplotlib.widgets import LassoSelector, RectangleSelector
 from napari.layers import Labels
 from napari_tools_menu import register_dock_widget
 from qtpy import QtWidgets
-from qtpy.QtCore import QTimer, Qt
-from qtpy.QtGui import QIcon, QGuiApplication
+from qtpy.QtCore import QTimer
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
     QComboBox,
     QHBoxLayout,
@@ -24,7 +24,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from ._utilities import get_layer_tabular_data, get_nice_colormap, add_column_to_layer_tabular_data
+from ._utilities import get_layer_tabular_data, get_nice_colormap
 
 ICON_ROOT = PathL(__file__).parent / "icons"
 
@@ -236,15 +236,7 @@ class PlotterWidget(QWidget):
             clustering_ID = "MANUAL_CLUSTER_ID"
 
             features = get_layer_tabular_data(self.analysed_layer)
-
-            modifiers = QGuiApplication.keyboardModifiers()
-            if modifiers == Qt.ShiftModifier and clustering_ID in features.keys():
-                former_clusters = features[clustering_ID]
-                former_clusters[inside] = np.max(former_clusters) + 1
-                features[clustering_ID] = former_clusters
-            else:
-                features[clustering_ID] = inside
-            add_column_to_layer_tabular_data(self.analysed_layer, clustering_ID, features[clustering_ID])
+            features[clustering_ID] = inside
 
             # redraw the whole plot
             self.run(

--- a/napari_clusters_plotter/_tests/test_clustering.py
+++ b/napari_clusters_plotter/_tests/test_clustering.py
@@ -40,18 +40,6 @@ def test_kmeans_clustering():
 
     # test without standardization
     result = kmeans_clustering(
-        standardize=False,
-        measurements=measurements,
-        cluster_number=n_centers,
-        iterations=50,
-    )
-
-    assert len(np.unique(result)) == n_centers
-    assert np.array_equal(1 - true_class, result)
-
-    # test with standardization
-    result = kmeans_clustering(
-        standardize=True,
         measurements=measurements,
         cluster_number=n_centers,
         iterations=50,
@@ -81,18 +69,6 @@ def test_hdbscan_clustering():
 
     # test without standardization
     result = hdbscan_clustering(
-        standardize=False,
-        measurements=measurements,
-        min_cluster_size=min_cluster_size,
-        min_samples=min_samples,
-    )
-
-    assert len(np.unique(result)) == 2
-    assert np.array_equal(true_class, result)
-
-    # test with standardization
-    result = hdbscan_clustering(
-        standardize=True,
         measurements=measurements,
         min_cluster_size=min_cluster_size,
         min_samples=min_samples,

--- a/napari_clusters_plotter/_tests/test_clustering.py
+++ b/napari_clusters_plotter/_tests/test_clustering.py
@@ -103,7 +103,7 @@ def test_gaussian_mixture_model():
     )
 
     assert len(np.unique(result)) == n_centers
-    assert np.array_equal(1 - true_class, result)
+    assert np.array_equal(true_class, result) or np.array_equal(1 - true_class, result)
 
 
 def test_agglomerative_clustering():
@@ -132,7 +132,7 @@ def test_agglomerative_clustering():
     )
 
     assert len(np.unique(result)) == n_centers
-    assert np.array_equal(true_class, result)
+    assert np.array_equal(true_class, result) or np.array_equal(1 - true_class, result)
 
 
 def test_mean_shift():
@@ -159,7 +159,7 @@ def test_mean_shift():
     )
 
     assert len(np.unique(result)) == n_centers
-    assert np.array_equal(true_class, result)
+    assert np.array_equal(true_class, result) or np.array_equal(1 - true_class, result)
 
 
 

--- a/napari_clusters_plotter/_tests/test_clustering.py
+++ b/napari_clusters_plotter/_tests/test_clustering.py
@@ -38,7 +38,7 @@ def test_kmeans_clustering():
 
     from napari_clusters_plotter._clustering import kmeans_clustering
 
-    # test without standardization
+    
     result = kmeans_clustering(
         measurements=measurements,
         cluster_number=n_centers,
@@ -67,7 +67,7 @@ def test_hdbscan_clustering():
     min_cluster_size = 5
     min_samples = 2  # number of samples that should be included in one cluster
 
-    # test without standardization
+    
     result = hdbscan_clustering(
         measurements=measurements,
         min_cluster_size=min_cluster_size,
@@ -78,6 +78,88 @@ def test_hdbscan_clustering():
     assert np.array_equal(true_class, result)
 
 
-if __name__ == "__main__":
-    test_kmeans_clustering()
-    test_hdbscan_clustering()
+def test_gaussian_mixture_model():
+
+    # create an example dataset
+    n_samples = 20
+    n_centers = 2
+    data = datasets.make_blobs(
+        n_samples=n_samples,
+        random_state=1,
+        centers=n_centers,
+        cluster_std=0.3,
+        n_features=2,
+    )
+
+    true_class = data[1]
+    measurements = data[0]
+
+    from napari_clusters_plotter._clustering import gaussian_mixture_model
+
+    
+    result = gaussian_mixture_model(
+        measurements=measurements,
+        cluster_number=2        
+    )
+
+    assert len(np.unique(result)) == n_centers
+    assert np.array_equal(1 - true_class, result)
+
+
+def test_agglomerative_clustering():
+
+    # create an example dataset
+    n_samples = 20
+    n_centers = 2
+    data = datasets.make_blobs(
+        n_samples=n_samples,
+        random_state=1,
+        centers=n_centers,
+        cluster_std=0.3,
+        n_features=2,
+    )
+
+    true_class = data[1]
+    measurements = data[0]
+
+    from napari_clusters_plotter._clustering import agglomerative_clustering
+
+    
+    result = agglomerative_clustering(
+        measurements=measurements,
+        cluster_number=2,
+        n_neighbors=2
+    )
+
+    assert len(np.unique(result)) == n_centers
+    assert np.array_equal(true_class, result)
+
+
+def test_mean_shift():
+    # create an example dataset
+    n_samples = 20
+    n_centers = 2
+    data = datasets.make_blobs(
+        n_samples=n_samples,
+        random_state=1,
+        centers=n_centers,
+        cluster_std=0.3,
+        n_features=2,
+    )
+
+    true_class = data[1]
+    measurements = data[0]
+
+    from napari_clusters_plotter._clustering import mean_shift
+
+    result = mean_shift(
+        measurements=measurements,
+        quantile=0.5,
+        n_samples=50
+    )
+
+    assert len(np.unique(result)) == n_centers
+    assert np.array_equal(true_class, result)
+
+
+

--- a/napari_clusters_plotter/_tests/test_clustering.py
+++ b/napari_clusters_plotter/_tests/test_clustering.py
@@ -147,6 +147,3 @@ def test_mean_shift():
 
     assert len(np.unique(result)) == n_centers
     assert np.array_equal(true_class, result) or np.array_equal(1 - true_class, result)
-
-
-


### PR DESCRIPTION
Hi Ryan @Cryaaa ,

this adds three new clustering methods to the clusters-plotter:
* [Gaussian Mixture Model (GMM)](https://scikit-learn.org/stable/modules/mixture.html)
* [Mean Shift (MS)](https://scikit-learn.org/stable/auto_examples/cluster/plot_mean_shift.html#sphx-glr-auto-examples-cluster-plot-mean-shift-py)
* [Agglomerative clustering (AC)](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.AgglomerativeClustering.html)

I also changed some of the clustering code to
* remove code duplication in the context of standard scaling
* remoded "SCALING" value from the "CLUSTER_ID" column name. I found that confusing. Happy to bring it back if it was important.

I wrote tests and tested the methods manually via the graphical user interface.

Would you mind reviewing the code @Cryaaa ? I don't want to bother Laura @lazigu until she's back :-)

No hurry btw. enjoy your weekend ☀️ 

Thanks!
Robert