### PR TITLE
Fix nans in measurements2

### DIFF
--- a/napari_clusters_plotter/_clustering.py
+++ b/napari_clusters_plotter/_clustering.py
@@ -19,6 +19,7 @@ from qtpy.QtWidgets import (
 
 from ._utilities import (
     add_column_to_layer_tabular_data,
+    catch_NaNs,
     get_layer_tabular_data,
     restore_defaults,
     widgets_inactive,
@@ -522,6 +523,7 @@ class ClusteringWidget(QWidget):
         show_table(self.viewer, labels_layer)
 
 
+@catch_NaNs
 def mean_shift(measurements, quantile=0.2, n_samples=50):
     from sklearn.cluster import MeanShift, estimate_bandwidth
 
@@ -531,6 +533,7 @@ def mean_shift(measurements, quantile=0.2, n_samples=50):
     return ms.fit_predict(measurements)
 
 
+@catch_NaNs
 def gaussian_mixture_model(measurements, cluster_number):
     from sklearn import mixture
 
@@ -540,6 +543,7 @@ def gaussian_mixture_model(measurements, cluster_number):
     return gmm.fit_predict(measurements)
 
 
+@catch_NaNs
 def kmeans_clustering(measurements, cluster_number, iterations):
     from sklearn.cluster import KMeans
 
@@ -548,6 +552,7 @@ def kmeans_clustering(measurements, cluster_number, iterations):
     return km.fit_predict(measurements)
 
 
+@catch_NaNs
 def agglomerative_clustering(measurements, cluster_number, n_neighbors):
     from sklearn.cluster import AgglomerativeClustering
     from sklearn.neighbors import kneighbors_graph
@@ -567,6 +572,7 @@ def agglomerative_clustering(measurements, cluster_number, n_neighbors):
     return ac.fit_predict(measurements)
 
 
+@catch_NaNs
 def hdbscan_clustering(measurements, min_cluster_size, min_samples):
     import hdbscan
 

--- a/napari_clusters_plotter/_dimensionality_reduction.py
+++ b/napari_clusters_plotter/_dimensionality_reduction.py
@@ -1,6 +1,7 @@
 import warnings
 from functools import partial
 
+import pandas as pd
 from magicgui.widgets import create_widget
 from napari.layers import Labels
 from napari_tools_menu import register_dock_widget
@@ -19,6 +20,7 @@ from qtpy.QtWidgets import (
 
 from ._utilities import (
     add_column_to_layer_tabular_data,
+    catch_NaNs,
     get_layer_tabular_data,
     restore_defaults,
     set_features,
@@ -456,7 +458,8 @@ class DimensionalityReductionWidget(QWidget):
         print("Dimensionality reduction finished")
 
 
-def umap(reg_props, n_neigh, n_components, standardize):
+@catch_NaNs
+def umap(reg_props: pd.DataFrame, n_neigh: int, n_components: int, standardize: bool):
     import umap.umap_ as umap
 
     reducer = umap.UMAP(
@@ -472,7 +475,10 @@ def umap(reg_props, n_neigh, n_components, standardize):
         return reducer.fit_transform(reg_props)
 
 
-def tsne(reg_props, perplexity, n_components, standardize):
+@catch_NaNs
+def tsne(
+    reg_props: pd.DataFrame, perplexity: float, n_components: int, standardize: bool
+):
     from sklearn.manifold import TSNE
 
     reducer = TSNE(
@@ -492,7 +498,10 @@ def tsne(reg_props, perplexity, n_components, standardize):
         return reducer.fit_transform(reg_props)
 
 
-def pca(reg_props, explained_variance_threshold, n_components):
+@catch_NaNs
+def pca(
+    reg_props: pd.DataFrame, explained_variance_threshold: float, n_components: int
+):
     from sklearn.decomposition import PCA
     from sklearn.preprocessing import StandardScaler
 

--- a/napari_clusters_plotter/_dimensionality_reduction.py
+++ b/napari_clusters_plotter/_dimensionality_reduction.py
@@ -1,6 +1,7 @@
 import warnings
 from functools import partial
 
+import numpy as np
 import pandas as pd
 from magicgui.widgets import create_widget
 from napari.layers import Labels
@@ -459,7 +460,9 @@ class DimensionalityReductionWidget(QWidget):
 
 
 @catch_NaNs
-def umap(reg_props: pd.DataFrame, n_neigh: int, n_components: int, standardize: bool):
+def umap(
+    reg_props: pd.DataFrame, n_neigh: int, n_components: int, standardize: bool
+) -> np.ndarray:
     import umap.umap_ as umap
 
     reducer = umap.UMAP(
@@ -478,7 +481,7 @@ def umap(reg_props: pd.DataFrame, n_neigh: int, n_components: int, standardize: 
 @catch_NaNs
 def tsne(
     reg_props: pd.DataFrame, perplexity: float, n_components: int, standardize: bool
-):
+) -> np.ndarray:
     from sklearn.manifold import TSNE
 
     reducer = TSNE(
@@ -501,7 +504,7 @@ def tsne(
 @catch_NaNs
 def pca(
     reg_props: pd.DataFrame, explained_variance_threshold: float, n_components: int
-):
+) -> np.ndarray:
     from sklearn.decomposition import PCA
     from sklearn.preprocessing import StandardScaler
 

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -464,7 +464,9 @@ class PlotterWidget(QWidget):
             and plot_cluster_name != "label"
             and plot_cluster_name in list(features.keys())
         ):
-            self.cluster_ids = features[plot_cluster_name]
+            # fill all prediction nan values with -1 -> turns them
+            # into noise points
+            self.cluster_ids = features[plot_cluster_name].fillna(-1)
 
             # get long colormap from function
             colors = get_nice_colormap()

--- a/napari_clusters_plotter/_tests/test_clustering.py
+++ b/napari_clusters_plotter/_tests/test_clustering.py
@@ -130,7 +130,11 @@ def test_gaussian_mixture_model():
     result = gaussian_mixture_model(measurements, cluster_number=2)
 
     assert np.isnan(result[n_samples // 2])
-    assert np.array_equal(result[~np.isnan(result)], 1 - true_class[~np.isnan(result)])
+
+    true_result = true_class[~np.isnan(result)].astype(bool)
+    result = result[~np.isnan(result)].astype(bool)
+
+    assert np.array_equal(result, 1 - true_result)
 
 
 def test_agglomerative_clustering():
@@ -201,4 +205,4 @@ def test_mean_shift():
 
 
 if __name__ == "__main__":
-    test_hdbscan_clustering()
+    test_gaussian_mixture_model()

--- a/napari_clusters_plotter/_tests/test_dimension_reduction.py
+++ b/napari_clusters_plotter/_tests/test_dimension_reduction.py
@@ -26,6 +26,47 @@ def test_clustering_widget(make_napari_viewer):
     assert len(viewer.window._dock_widgets) == n_wdgts + 1
 
 
+def test_bad_measurements(make_napari_viewer):
+
+    from napari_clusters_plotter._dimensionality_reduction import (
+        DimensionalityReductionWidget,
+    )
+    from napari_clusters_plotter._measure import get_regprops_from_regprops_source
+    from napari_clusters_plotter._utilities import set_features
+
+    label = np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 1, 0, 0, 2, 2],
+            [0, 0, 0, 0, 2, 2, 2],
+            [3, 3, 0, 0, 0, 0, 0],
+            [0, 0, 4, 4, 0, 0, 0],
+            [6, 6, 6, 6, 0, 5, 0],  # <-single pixel label leading to NaN meas.
+            [0, 7, 7, 0, 0, 0, 0],
+        ]
+    )
+
+    viewer = make_napari_viewer()
+    labels_layer = viewer.add_labels(label)
+
+    image = np.random.random(label.shape)
+    measurements = get_regprops_from_regprops_source(image, label, "shape + intensity")
+    set_features(labels_layer, measurements)
+
+    widget = DimensionalityReductionWidget(napari_viewer=viewer)
+    widget.run(
+        labels_layer=labels_layer,
+        selected_measurements_list=list(measurements.keys()),
+        n_neighbours=2,
+        perplexity=5,
+        selected_algorithm="UMAP",
+        standardize=False,
+        n_components=2,
+        explained_variance=95.0,
+        pca_components=0,
+    )
+
+
 def test_call_to_function(make_napari_viewer):
 
     viewer = make_napari_viewer()
@@ -146,5 +187,7 @@ def test_pca():
 
 
 if __name__ == "__main__":
-    test_clustering_widget()
-    test_call_to_function()
+    import napari
+
+    # test_clustering_widget()
+    test_bad_measurements(napari.Viewer)

--- a/napari_clusters_plotter/_tests/test_dimension_reduction.py
+++ b/napari_clusters_plotter/_tests/test_dimension_reduction.py
@@ -146,15 +146,17 @@ def test_call_to_function(make_napari_viewer):
 
 def test_umap():
 
+    import pandas as pd
+
     from napari_clusters_plotter._dimensionality_reduction import umap
 
     X = np.array([[0, 0, 0], [0, 1, 1], [1, 0, 1], [1, 1, 1]])
     n_comp = 2
 
-    result = umap(X, n_neigh=2, n_components=n_comp, standardize=True)
+    result = umap(pd.DataFrame(X), n_neigh=2, n_components=n_comp, standardize=True)
     assert result.shape[-1] == n_comp
 
-    result = umap(X, n_neigh=2, n_components=n_comp, standardize=False)
+    result = umap(pd.DataFrame(X), n_neigh=2, n_components=n_comp, standardize=False)
     assert result.shape[-1] == n_comp
 
 
@@ -163,12 +165,14 @@ def test_tsne():
     X = np.array([[0, 0, 0], [0, 1, 1], [1, 0, 1], [1, 1, 1]])
     n_comp = 2
 
+    import pandas as pd
+
     from napari_clusters_plotter._dimensionality_reduction import tsne
 
-    result = tsne(X, perplexity=5, n_components=2, standardize=False)
+    result = tsne(pd.DataFrame(X), perplexity=5, n_components=2, standardize=False)
     assert result.shape[-1] == n_comp
 
-    result = tsne(X, perplexity=5, n_components=2, standardize=True)
+    result = tsne(pd.DataFrame(X), perplexity=5, n_components=2, standardize=True)
     assert result.shape[-1] == n_comp
 
 
@@ -177,17 +181,20 @@ def test_pca():
     X = np.array([[0, 0, 0], [0, 1, 1], [1, 0, 1], [1, 1, 1]])
     n_comp = 3
 
+    import pandas as pd
+
     from napari_clusters_plotter._dimensionality_reduction import pca
 
-    result = pca(X, explained_variance_threshold=95.0, n_components=0)
+    result = pca(pd.DataFrame(X), explained_variance_threshold=95.0, n_components=0)
     assert result.shape[-1] == n_comp
 
-    result = pca(X, explained_variance_threshold=95.0, n_components=0)
+    result = pca(pd.DataFrame(X), explained_variance_threshold=95.0, n_components=0)
     assert result.shape[-1] == n_comp
 
 
 if __name__ == "__main__":
-    import napari
+    pass
 
     # test_clustering_widget()
-    test_bad_measurements(napari.Viewer)
+    # test_bad_measurements(napari.Viewer)
+    # test_umap()

--- a/napari_clusters_plotter/_tests/test_dimension_reduction.py
+++ b/napari_clusters_plotter/_tests/test_dimension_reduction.py
@@ -31,7 +31,6 @@ def test_bad_measurements(make_napari_viewer):
     from napari_clusters_plotter._dimensionality_reduction import (
         DimensionalityReductionWidget,
     )
-    from napari_clusters_plotter._measure import get_regprops_from_regprops_source
     from napari_clusters_plotter._utilities import set_features
 
     label = np.array(
@@ -49,8 +48,13 @@ def test_bad_measurements(make_napari_viewer):
     viewer = make_napari_viewer()
     labels_layer = viewer.add_labels(label)
 
-    image = np.random.random(label.shape)
-    measurements = get_regprops_from_regprops_source(image, label, "shape + intensity")
+    # Add NaNs to data
+    measurements = measure.regionprops_table(
+        label, properties=(["label", "area", "perimeter"])
+    )
+    for key in list(measurements.keys())[1:]:
+        measurements[key] = measurements[key].astype(float)
+        measurements[key][4] = np.nan
     set_features(labels_layer, measurements)
 
     widget = DimensionalityReductionWidget(napari_viewer=viewer)
@@ -198,5 +202,5 @@ if __name__ == "__main__":
     # test_clustering_widget()
     import napari
 
-    test_call_to_function(napari.Viewer)
+    test_bad_measurements(napari.Viewer)
     # test_umap()

--- a/napari_clusters_plotter/_tests/test_dimension_reduction.py
+++ b/napari_clusters_plotter/_tests/test_dimension_reduction.py
@@ -137,7 +137,7 @@ def test_call_to_function(make_napari_viewer):
         standardize=False,
         n_components=2,
         explained_variance=95.0,
-        pca_components=0,
+        pca_components=2,
     )
 
     result = get_layer_tabular_data(label_layer)
@@ -196,5 +196,7 @@ if __name__ == "__main__":
     pass
 
     # test_clustering_widget()
-    # test_bad_measurements(napari.Viewer)
+    import napari
+
+    test_call_to_function(napari.Viewer)
     # test_umap()

--- a/napari_clusters_plotter/_tests/test_utils.py
+++ b/napari_clusters_plotter/_tests/test_utils.py
@@ -31,7 +31,10 @@ def test_feature_setting(make_napari_viewer):
     some_features = pd.DataFrame({"A": [1, 2, 3], "B": [4, 5, 6]})
     set_features(label_layer, some_features)
 
-    assert isinstance(label_layer.features, pd.DataFrame)
+    if hasattr(label_layer, "features"):
+        assert isinstance(label_layer.features, pd.DataFrame)
+    elif hasattr(label_layer, "properties"):
+        assert isinstance(label_layer.properties, dict)
 
     some_features = get_layer_tabular_data(label_layer)
     assert isinstance(some_features, pd.DataFrame)
@@ -42,4 +45,6 @@ def test_feature_setting(make_napari_viewer):
 
 
 if __name__ == "__main__":
-    test_feature_setting()
+    import napari
+
+    test_feature_setting(napari.Viewer)

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -47,17 +47,20 @@ def catch_NaNs(func):
 
     @wraps(func)
     def wrapper(*args, **kwargs):
-        reg_props = args[0].copy()  # this should be a DataFrame
-        non_nan_entries = reg_props.dropna().index
+        measurements = args[0].copy()  # this should be a DataFrame
+
+        if isinstance(measurements, np.ndarray):
+            measurements = pd.DataFrame(measurements)
+        non_nan_entries = measurements.dropna().index
 
         new_args = list(args)
-        new_args[0] = reg_props.dropna()
+        new_args[0] = measurements.dropna()
         embedded = func(*new_args, **kwargs)
 
         result = pd.DataFrame(embedded, index=non_nan_entries)
-        result = result.reindex(np.arange(len(reg_props)))
+        result = result.reindex(np.arange(len(measurements)))
 
-        return result.to_numpy()
+        return result.to_numpy().squeeze()
 
     return wrapper
 


### PR DESCRIPTION
Closes #65 

Another approach to handling NaNs in the measured properties. I created a decorator for all functions that need to handle data which may potentially be polluted with NaNs.

The decorator assumes that the data is 
* passed as an argument
* the first argument

I think these are reasonable assumptions. The NaNs are then cleared from the data, fed to the decorated function and the original dimensions are restored before returning the data, see [here](https://github.com/BiAPoL/napari-clusters-plotter/blob/760918e2b823f4ef2a25e2ff24e9264f7c20baa6/napari_clusters_plotter/_utilities.py#L45).

Let me know what you think!