### PR TITLE
Add custom results name field

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     - id: black
       pass_filenames: true

--- a/napari_clusters_plotter/_tests/test_clustering.py
+++ b/napari_clusters_plotter/_tests/test_clustering.py
@@ -134,7 +134,7 @@ def test_gaussian_mixture_model():
     true_result = true_class[~np.isnan(result)].astype(bool)
     result = result[~np.isnan(result)].astype(bool)
 
-    assert np.array_equal(result, 1 - true_result)
+    assert np.array_equal(result, 1 - true_result) or np.array_equal(result, true_result)
 
 
 def test_agglomerative_clustering():

--- a/napari_clusters_plotter/_tests/test_clustering.py
+++ b/napari_clusters_plotter/_tests/test_clustering.py
@@ -134,7 +134,9 @@ def test_gaussian_mixture_model():
     true_result = true_class[~np.isnan(result)].astype(bool)
     result = result[~np.isnan(result)].astype(bool)
 
-    assert np.array_equal(result, 1 - true_result) or np.array_equal(result, true_result)
+    assert np.array_equal(result, 1 - true_result) or np.array_equal(
+        result, true_result
+    )
 
 
 def test_agglomerative_clustering():

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = napari-clusters-plotter
 version = 0.2.2
-author = Laura Zigutyte, Ryan Savill, Marcelo Zoccoler, Robert Haase
+author = Laura Zigutyte, Ryan Savill, Johannes Müller, Marcelo Zoccoler, Robert Haase
 author_email = zigutyte@gmail.com, robert.haase@tu-dresden.de
 
 url = https://github.com/BiAPoL/napari-clusters-plotter


### PR DESCRIPTION
A minor PR to add a custom name for clustering results that I separated from the timelapse branch where I implemented this. Closes https://github.com/BiAPoL/napari-clusters-plotter/issues/68. @Cryaaa, I appreciate if you can take a look and it works fine for you also. After this is merged I would make a release if you agree.