### PR TITLE
Removing the setting of the backend

### DIFF
--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -33,9 +33,6 @@ from ._utilities import (
 
 ICON_ROOT = PathL(__file__).parent / "icons"
 
-matplotlib.use("Qt5Agg")
-
-
 # Class below was based upon matplotlib lasso selection example:
 # https://matplotlib.org/stable/gallery/widgets/lasso_selector_demo_sgskip.html
 class SelectFromCollection:

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -2,7 +2,6 @@ import os
 import warnings
 from pathlib import Path as PathL
 
-import matplotlib
 import numpy as np
 import pandas as pd
 from magicgui.widgets import create_widget

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -32,6 +32,7 @@ from ._utilities import (
 
 ICON_ROOT = PathL(__file__).parent / "icons"
 
+
 # Class below was based upon matplotlib lasso selection example:
 # https://matplotlib.org/stable/gallery/widgets/lasso_selector_demo_sgskip.html
 class SelectFromCollection:


### PR DESCRIPTION
This was causing some issues when napari was run from a notebook (see #76). My testing didn't show  any loss of functionality when we do not set the backend explicitly. If tests pass this will be merged.