### PR TITLE
connecting a labels property event to auto update properties in widgets

### DIFF
--- a/napari_clusters_plotter/_clustering.py
+++ b/napari_clusters_plotter/_clustering.py
@@ -391,7 +391,7 @@ class ClusteringWidget(QWidget):
         # update measurements list when a new labels layer is selected
         self.labels_select.changed.connect(self.update_properties_list)
 
-        # update axes combo boxes automatically if features of 
+        # update axes combo boxes automatically if features of
         # layer are changed
         self.last_connected = None
         self.labels_select.changed.connect(self.activate_property_autoupdate)
@@ -468,7 +468,9 @@ class ClusteringWidget(QWidget):
 
     def activate_property_autoupdate(self):
         if self.last_connected is not None:
-            self.last_connected.events.properties.disconnect(self.update_properties_list)
+            self.last_connected.events.properties.disconnect(
+                self.update_properties_list
+            )
         self.labels_select.value.events.properties.connect(self.update_properties_list)
         self.last_connected = self.labels_select.value
 

--- a/napari_clusters_plotter/_clustering.py
+++ b/napari_clusters_plotter/_clustering.py
@@ -391,6 +391,11 @@ class ClusteringWidget(QWidget):
         # update measurements list when a new labels layer is selected
         self.labels_select.changed.connect(self.update_properties_list)
 
+        # update axes combo boxes automatically if features of 
+        # layer are changed
+        self.last_connected = None
+        self.labels_select.changed.connect(self.activate_property_autoupdate)
+
         # go through all widgets and change spacing
         for i in range(self.layout().count()):
             item = self.layout().itemAt(i).widget()
@@ -460,6 +465,12 @@ class ClusteringWidget(QWidget):
                     item = QListWidgetItem(p)
                     self.properties_list.addItem(item)
                     item.setSelected(True)
+
+    def activate_property_autoupdate(self):
+        if self.last_connected is not None:
+            self.last_connected.events.properties.disconnect(self.update_properties_list)
+        self.labels_select.value.events.properties.connect(self.update_properties_list)
+        self.last_connected = self.labels_select.value
 
     def showEvent(self, event) -> None:
         super().showEvent(event)

--- a/napari_clusters_plotter/_dimensionality_reduction.py
+++ b/napari_clusters_plotter/_dimensionality_reduction.py
@@ -270,7 +270,6 @@ class DimensionalityReductionWidget(QWidget):
         run_button.clicked.connect(run_clicked)
         update_button.clicked.connect(self.update_properties_list)
         defaults_button.clicked.connect(partial(restore_defaults, self, DEFAULTS))
-        
 
         # update measurements list when a new labels layer is selected
         self.labels_select.changed.connect(self.update_properties_list)
@@ -380,7 +379,9 @@ class DimensionalityReductionWidget(QWidget):
 
     def activate_property_autoupdate(self):
         if self.last_connected is not None:
-            self.last_connected.events.properties.disconnect(self.update_properties_list)
+            self.last_connected.events.properties.disconnect(
+                self.update_properties_list
+            )
         self.labels_select.value.events.properties.connect(self.update_properties_list)
         self.last_connected = self.labels_select.value
 

--- a/napari_clusters_plotter/_dimensionality_reduction.py
+++ b/napari_clusters_plotter/_dimensionality_reduction.py
@@ -270,9 +270,13 @@ class DimensionalityReductionWidget(QWidget):
         run_button.clicked.connect(run_clicked)
         update_button.clicked.connect(self.update_properties_list)
         defaults_button.clicked.connect(partial(restore_defaults, self, DEFAULTS))
+        
 
         # update measurements list when a new labels layer is selected
         self.labels_select.changed.connect(self.update_properties_list)
+
+        self.last_connected = None
+        self.labels_select.changed.connect(self.activate_property_autoupdate)
 
         # adding all widgets to the layout
         self.layout().addWidget(label_container)
@@ -373,6 +377,12 @@ class DimensionalityReductionWidget(QWidget):
                     item = QListWidgetItem(p)
                     self.properties_list.addItem(item)
                     item.setSelected(True)
+
+    def activate_property_autoupdate(self):
+        if self.last_connected is not None:
+            self.last_connected.events.properties.disconnect(self.update_properties_list)
+        self.labels_select.value.events.properties.connect(self.update_properties_list)
+        self.last_connected = self.labels_select.value
 
     # this function runs after the run button is clicked
     def run(

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -427,6 +427,11 @@ class PlotterWidget(QWidget):
         # update axes combo boxes once a new label layer is selected
         self.labels_select.changed.connect(self.update_axes_list)
 
+        # update axes combo boxes automatically if features of 
+        # layer are changed
+        self.last_connected = None
+        self.labels_select.changed.connect(self.activate_property_autoupdate)
+
         # update axes combo boxes once update button is clicked
         update_button.clicked.connect(self.update_axes_list)
 
@@ -441,6 +446,12 @@ class PlotterWidget(QWidget):
 
     def reset_choices(self, event=None):
         self.labels_select.reset_choices(event)
+
+    def activate_property_autoupdate(self):
+        if self.last_connected is not None:
+            self.last_connected.events.properties.disconnect(self.update_axes_list)
+        self.labels_select.value.events.properties.connect(self.update_axes_list)
+        self.last_connected = self.labels_select.value
 
     def update_axes_list(self):
         selected_layer = self.labels_select.value

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -427,7 +427,7 @@ class PlotterWidget(QWidget):
         # update axes combo boxes once a new label layer is selected
         self.labels_select.changed.connect(self.update_axes_list)
 
-        # update axes combo boxes automatically if features of 
+        # update axes combo boxes automatically if features of
         # layer are changed
         self.last_connected = None
         self.labels_select.changed.connect(self.activate_property_autoupdate)


### PR DESCRIPTION
This implements the changes @haesleinhuepf suggested in #90. For me this works, maybe others can also test if the functionality works for them! We could also change the event used in case this is changed in future napari updates since at the moment it uses the properties event of a layer even though the features of the layer are updated...