### PR TITLE
Fix the license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2022, DFG Cluster of Excellence "Physics of Life" TU Dresden, Robert Haase, Laura Zigutyte, Marcello Zoccoler, Ryan Savill
+Copyright (c) 2022, DFG Cluster of Excellence "Physics of Life" TU Dresden, Robert Haase, Laura Zigutyte, Marcello Zoccoler, Ryan Savill, Johannes Müller
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,4 @@
-
-Copyright (c) DFG Cluster of Excellence "Physics of Life", TU Dresden, 2021, Robert Haase, Laura Zigutyte,
-Marcello Zoccoler, Ryan Savill
+Copyright (c) 2022, DFG Cluster of Excellence "Physics of Life" TU Dresden, Robert Haase, Laura Zigutyte, Marcello Zoccoler, Ryan Savill
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
Hi all @lazigu, @Cryaaa @zoccoler @jo-mueller 

this is just a minor fix in the license: year first, names in the same line after. This file is parsed be programs and must be in the right format. After this change, I would expect it doesn't look like this anymore:

![image](https://user-images.githubusercontent.com/12660498/168068180-31b70edc-0c80-43e6-959b-d2d7d0830fe9.png)

but like this:

![image](https://user-images.githubusercontent.com/12660498/168068262-be3fedb0-626e-4313-ace7-18cd21a53c9e.png)

I was also wondering if Johannes wants to be in the list. If so, Johannes, please use the suggestion tool of github and add yourself as part of this PR. If anybody else could merge afterwards, that would  be great.

Thanks!
Robert