### PR TITLE
don't redraw plot in case the plot is invisible

### DIFF
--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -489,6 +489,9 @@ class PlotterWidget(QWidget):
         plot_cluster_name=None,
         redraw_cluster_image=True,
     ):
+        if not self.isVisible():
+            # don't redraw in case the plot is invisible anyway
+            return
 
         self.data_x = features[plot_x_axis_name]
         self.data_y = features[plot_y_axis_name]


### PR DESCRIPTION
Hi Ryan @Cryaaa ,

this fixes a performance issue when working with timelapse data and the cluster plotter.

I noticed that napari becomes slower and slower if one hides the plotter widget and starts it from the menu again. The reason is that in the background all the invisible plots were redrawn whenever the user changed the current timepoints.

This PR fixes this. 

Let me know what you think!

If you merge it, please make a new release. I'd like to show the clusters plotter in a course in a week.

Thanks!

Best,
Robert