### PR TITLE
remove constraint for python version < 3.10

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ classifiers =
 
 [options]
 packages = find:
-python_requires = >=3.7, <3.10
+python_requires = >=3.7
 
 # add your package requirements here
 install_requires =


### PR DESCRIPTION
Hi Laura @lazigu ,

do you see any issue with removing the constraint python < 3.10? 

I just tested UMAP in the clusters-plotter like this and it worked like a charm:
```
conda create --name test2 python==3.10 napari napari-segment-blobs-and-things-with-membranes -c conda-forge
conda activate test2
git clone https://github.com/BiAPoL/napari-clusters-plotter.git
cd napari-clusters-plotter
notepad setup.py
```
... remove constraint `, < 3.10`

```
pip install -e .
```
Then I tested the ncp/measurement and dimensionality reduction UMAP on blobs.tif and a corresponding label image.

Let me know what you think! If it's ok to merge it (I'm happy to do the merge and release) this closes #126 

Best,
Robert