### PR TITLE
Create codecov.yml

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5% # allow for 5% reduction of coverage without failing


### PR DESCRIPTION
This PR adds _codecov.yml_ config file to change the default setting that makes codecov check to fail if a PR decreases the coverage by more than 0%. Now the threshold will be 5%.