### PR TITLE
Remove pinned version of joblib

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,9 +45,7 @@ install_requires =
     napari-tools-menu
     napari-skimage-regionprops>=0.3.1
     hdbscan
-    # todo: remove joblib constraint after the issue with hdbscan is fixed:
-    # https://github.com/scikit-learn-contrib/hdbscan/issues/565
-    joblib==1.1.0
+    joblib
 
 
 [options.entry_points]


### PR DESCRIPTION
This closes #135.
The issue that required pinning the version of joblib, seems to be fixed in the newest HDBSCAN version (0.8.29).