### PR TITLE
Fill measurement lists when initializing dock widgets

### DIFF
--- a/napari_clusters_plotter/_clustering.py
+++ b/napari_clusters_plotter/_clustering.py
@@ -288,6 +288,8 @@ class ClusteringWidget(QWidget):
             self.change_clustering_options_visibility
         )
 
+        update_properties_list(self, [ID_NAME])
+
     def change_clustering_options_visibility(self):
         widgets_active(
             self.kmeans_settings_container_nr,

--- a/napari_clusters_plotter/_dimensionality_reduction.py
+++ b/napari_clusters_plotter/_dimensionality_reduction.py
@@ -279,6 +279,8 @@ class DimensionalityReductionWidget(QWidget):
         # hide widgets unless appropriate options are chosen
         self.algorithm_choice_list.changed.connect(self.change_settings_visibility)
 
+        update_properties_list(self, EXCLUDE)
+
     def showEvent(self, event) -> None:
         super().showEvent(event)
         self.reset_choices()

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -239,6 +239,8 @@ class PlotterWidget(QWidget):
 
         self.viewer.dims.events.current_step.connect(frame_changed)
 
+        self.update_axes_list()
+
     def showEvent(self, event) -> None:
         super().showEvent(event)
         self.reset_choices()


### PR DESCRIPTION
This closes #177 by programmatically clicking the `Update Measurements` button after the widget has been initialized.