### PR TITLE
Add a check whether given axes names exist when plotting from notebook

### DIFF
--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -294,6 +294,16 @@ class PlotterWidget(QWidget):
             # don't redraw in case the plot is invisible anyway
             return
 
+        # check whether given axes names exist and if not don't redraw
+        if (
+            plot_x_axis_name not in features.columns
+            or plot_y_axis_name not in features.columns
+        ):
+            print(
+                "Selected measurements do not exist in layer's properties/features. The plot is not (re)drawn."
+            )
+            return
+
         self.data_x = features[plot_x_axis_name]
         self.data_y = features[plot_y_axis_name]
         self.plot_x_axis_name = plot_x_axis_name


### PR DESCRIPTION
This small PR adds a check so that the given axes' names would be checked when plotting from a jupyter notebook.
I would send a PR to update this [notebook](https://github.com/BiAPoL/napari-clusters-plotter-example-notebooks/blob/main/notebooks/plotting_in_napari.ipynb) after this is merged and released.
E.g. when a typo is made in "area":
![image](https://user-images.githubusercontent.com/52177660/222760908-7dffb922-2d47-41a0-beee-006f0ffd0374.png)
