### PR TITLE
Set unselected datapoints as background/noise

### DIFF
--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -16,6 +16,7 @@ from ._Qt_code import (
     MplCanvas,
     MyNavigationToolbar,
     SelectFromCollection,
+    collapsible_box,
     button,
     labels_container_and_selection,
     title,
@@ -138,6 +139,7 @@ class PlotterWidget(QWidget):
         update_container, update_button = button("Update Measurements")
 
         # checkbox background
+        self.advanced_options_container = collapsible_box("Expand for advanced options")
         def checkbox_status_changed():
             if self.cluster_ids is not None:
                 clustering_ID = "MANUAL_CLUSTER_ID"
@@ -157,13 +159,14 @@ class PlotterWidget(QWidget):
         self.plot_hide_non_selected = QCheckBox()
         self.plot_hide_non_selected.stateChanged.connect(checkbox_status_changed)
         checkbox_container.layout().addWidget(self.plot_hide_non_selected)
+        self.advanced_options_container.addWidget(checkbox_container)
 
         # adding all widgets to the layout
         self.layout().addWidget(label_container)
         self.layout().addWidget(labels_layer_selection_container)
         self.layout().addWidget(axes_container)
         self.layout().addWidget(cluster_container)
-        self.layout().addWidget(checkbox_container)
+        self.layout().addWidget(self.advanced_options_container)
         self.layout().addWidget(update_container)
         self.layout().addWidget(run_container)
         self.layout().setSpacing(0)

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -8,7 +8,14 @@ from napari_tools_menu import register_dock_widget
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QGuiApplication, QIcon
-from qtpy.QtWidgets import QComboBox, QHBoxLayout, QLabel, QVBoxLayout, QWidget, QCheckBox
+from qtpy.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QHBoxLayout,
+    QLabel,
+    QVBoxLayout,
+    QWidget,
+)
 
 from ._plotter_utilities import clustered_plot_parameters, unclustered_plot_parameters
 from ._Qt_code import (
@@ -16,8 +23,8 @@ from ._Qt_code import (
     MplCanvas,
     MyNavigationToolbar,
     SelectFromCollection,
-    collapsible_box,
     button,
+    collapsible_box,
     labels_container_and_selection,
     title,
 )
@@ -140,6 +147,7 @@ class PlotterWidget(QWidget):
 
         # checkbox background
         self.advanced_options_container = collapsible_box("Expand for advanced options")
+
         def checkbox_status_changed():
             if self.cluster_ids is not None:
                 clustering_ID = "MANUAL_CLUSTER_ID"
@@ -179,9 +187,6 @@ class PlotterWidget(QWidget):
 
         # adding spacing between fields for selecting two axes
         axes_container.layout().setSpacing(6)
-
-
-
 
         def run_clicked():
             if self.labels_select.value is None:
@@ -345,9 +350,10 @@ class PlotterWidget(QWidget):
             and plot_cluster_name != "label"
             and plot_cluster_name in list(features.keys())
         ):
-
             if self.plot_hide_non_selected.isChecked():
-                features[plot_cluster_name][features[plot_cluster_name]==0] = -1 # make unselected points to noise points
+                features[plot_cluster_name][
+                    features[plot_cluster_name] == 0
+                ] = -1  # make unselected points to noise points
 
             # fill all prediction nan values with -1 -> turns them
             # into noise points

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -351,10 +351,9 @@ class PlotterWidget(QWidget):
             and plot_cluster_name in list(features.keys())
         ):
             if self.plot_hide_non_selected.isChecked():
-                features[plot_cluster_name][
-                    features[plot_cluster_name] == 0
+                features.loc[
+                    features[plot_cluster_name] == 0, plot_cluster_name
                 ] = -1  # make unselected points to noise points
-
             # fill all prediction nan values with -1 -> turns them
             # into noise points
             self.cluster_ids = features[plot_cluster_name].fillna(-1)

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -73,6 +73,7 @@ class PlotterWidget(QWidget):
                 self.plot_y_axis_name,
                 plot_cluster_name=clustering_ID,
             )
+            self.labels_select.value.visible = False
 
         # Canvas Widget that displays the 'figure', it takes the 'figure' instance
         self.graphics_widget = MplCanvas(


### PR DESCRIPTION
This is an implementation for this issue:
closes #192

I followed the instructions @lazigu gave in #191 .

This how it looks when you freshly load data:
![image](https://user-images.githubusercontent.com/1113977/223454794-bc4e18c0-38eb-4db3-8638-be67549c3896.png)

This is how it looks when you circled your first cluster:
![image](https://user-images.githubusercontent.com/1113977/223455266-c3f766df-23e3-4047-b74a-7bac6940108b.png)

This is how it looks when you activate the checkbox:
![image](https://user-images.githubusercontent.com/1113977/223456141-d2a3bced-05e5-4494-9e54-ca56a7baa997.png)

The plot is automatically redrawn when the checkbox state is changed.

I automatically make the label layer invisible when I select the first cluster. Otherwise it would look like this after clustering:
![image](https://user-images.githubusercontent.com/1113977/223456795-fbf7352c-bf88-4c9e-acbd-d09939c46448.png)


Issue that I see:

- Expanding the collapsible box takes ages if you have a dataset with many points (like we do). Probably because it needs to redraw the plot. Any ideas on this @lazigu ?

Best,
Thorsten




