### PR TITLE
Fix axes labels not displayed bug

### DIFF
--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -418,7 +418,7 @@ class SelectFromCollection:
 
 class MplCanvas(FigureCanvas):
     def __init__(self, parent=None, width=7, height=4, manual_clustering_method=None):
-        self.fig = Figure(figsize=(width, height))
+        self.fig = Figure(figsize=(width, height), constrained_layout=True)
         self.manual_clustering_method = manual_clustering_method
 
         # changing color of axes background to napari main window color

--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -436,9 +436,13 @@ class MplCanvas(FigureCanvas):
         self.axes.xaxis.label.set_color("white")
         self.axes.yaxis.label.set_color("white")
 
-        # changing colors of axes labels
+        # changing colors of axes ticks
         self.axes.tick_params(axis="x", colors="white")
         self.axes.tick_params(axis="y", colors="white")
+
+        # changing colors of axes labels
+        self.axes.xaxis.label.set_color("white")
+        self.axes.yaxis.label.set_color("white")
 
         super().__init__(self.fig)
 
@@ -505,30 +509,40 @@ class MyNavigationToolbar(NavigationToolbar):
                 )
 
     def save_figure(self):
-        self.canvas.fig.set_facecolor("#00000000")
-        self.canvas.fig.axes[0].set_facecolor("#00000000")
-        self.canvas.axes.tick_params(color="black")
+        # setting the background of the saved figure to white
+        self.canvas.fig.set_facecolor("#ffffff")
+        self.canvas.fig.axes[0].set_facecolor("#ffffff")
 
+        # setting axes colors of the saved figure to black
         self.canvas.axes.spines["bottom"].set_color("black")
         self.canvas.axes.spines["top"].set_color("black")
         self.canvas.axes.spines["right"].set_color("black")
         self.canvas.axes.spines["left"].set_color("black")
 
-        # changing colors of axis labels
+        # changing colors of axes ticks and labels for the saved figure
         self.canvas.axes.tick_params(axis="x", colors="black")
         self.canvas.axes.tick_params(axis="y", colors="black")
 
+        self.canvas.axes.xaxis.label.set_color("black")
+        self.canvas.axes.yaxis.label.set_color("black")
+
         super().save_figure()
 
-        self.canvas.axes.tick_params(color="white")
+        # changing background color back to napari's dark theme color
+        self.canvas.fig.set_facecolor("#262930")
+        self.canvas.fig.axes[0].set_facecolor("#262930")
 
+        # changing other colors back to white
         self.canvas.axes.spines["bottom"].set_color("white")
         self.canvas.axes.spines["top"].set_color("white")
         self.canvas.axes.spines["right"].set_color("white")
         self.canvas.axes.spines["left"].set_color("white")
 
-        # changing colors of axis labels
+        # changing colors of axes ticks and labels back to white
         self.canvas.axes.tick_params(axis="x", colors="white")
         self.canvas.axes.tick_params(axis="y", colors="white")
+
+        self.canvas.axes.xaxis.label.set_color("white")
+        self.canvas.axes.yaxis.label.set_color("white")
 
         self.canvas.draw()

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -454,7 +454,16 @@ class PlotterWidget(QWidget):
                 self.graphics_widget.axes,
                 self.graphics_widget.pts,
             )
+            self.graphics_widget.axes.xaxis.label.set_color("white")
+            self.graphics_widget.axes.yaxis.label.set_color("white")
+            self.graphics_widget.axes.set_xlabel(plot_x_axis_name)
+            self.graphics_widget.axes.set_ylabel(plot_y_axis_name)
+
             self.graphics_widget.draw()  # Only redraws when cluster is not manually selected
             # because manual selection already does that elsewhere
+
+        self.graphics_widget.axes.xaxis.label.set_color("white")
+        self.graphics_widget.axes.yaxis.label.set_color("white")
+
         self.graphics_widget.axes.set_xlabel(plot_x_axis_name)
         self.graphics_widget.axes.set_ylabel(plot_y_axis_name)

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -8,7 +8,15 @@ from napari_tools_menu import register_dock_widget
 from qtpy import QtWidgets
 from qtpy.QtCore import Qt
 from qtpy.QtGui import QGuiApplication, QIcon
-from qtpy.QtWidgets import QComboBox, QHBoxLayout, QLabel, QVBoxLayout, QWidget
+from qtpy.QtWidgets import (
+    QComboBox,
+    QHBoxLayout,
+    QLabel,
+    QMainWindow,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
 
 from ._plotter_utilities import clustered_plot_parameters, unclustered_plot_parameters
 from ._Qt_code import (
@@ -33,12 +41,24 @@ POINTER = "frame"
 
 @register_dock_widget(menu="Measurement > Plot measurements (ncp)")
 @register_dock_widget(menu="Visualization > Plot measurements (ncp)")
-class PlotterWidget(QWidget):
+class PlotterWidget(QMainWindow):
     def __init__(self, napari_viewer):
         super().__init__()
 
         self.cluster_ids = None
         self.viewer = napari_viewer
+
+        # create a scroll area
+        self.scrollArea = QScrollArea()
+        self.setCentralWidget(self.scrollArea)
+        self.scrollArea.setWidgetResizable(True)
+        self.scrollArea.setHorizontalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
+
+        self.contents = QWidget()
+        self.scrollArea.setWidget(self.contents)
+
+        self.layout = QVBoxLayout(self.contents)
+        self.layout.setAlignment(Qt.AlignTop)
 
         # a figure instance to plot on
         self.figure = Figure()
@@ -99,14 +119,12 @@ class PlotterWidget(QWidget):
 
         # create a placeholder widget to hold the toolbar and graphics widget.
         graph_container = QWidget()
-        graph_container.setMaximumHeight(500)
+        graph_container.setMinimumHeight(300)
         graph_container.setLayout(QtWidgets.QVBoxLayout())
         graph_container.layout().addWidget(self.toolbar)
         graph_container.layout().addWidget(self.graphics_widget)
 
-        # QVBoxLayout - lines up widgets vertically
-        self.setLayout(QVBoxLayout())
-        self.layout().addWidget(graph_container)
+        self.layout.addWidget(graph_container, alignment=Qt.AlignTop)
 
         label_container = title("<b>Plotting</b>")
 
@@ -137,17 +155,17 @@ class PlotterWidget(QWidget):
         update_container, update_button = button("Update Measurements")
 
         # adding all widgets to the layout
-        self.layout().addWidget(label_container)
-        self.layout().addWidget(labels_layer_selection_container)
-        self.layout().addWidget(axes_container)
-        self.layout().addWidget(cluster_container)
-        self.layout().addWidget(update_container)
-        self.layout().addWidget(run_container)
-        self.layout().setSpacing(0)
+        self.layout.addWidget(label_container, alignment=Qt.AlignTop)
+        self.layout.addWidget(labels_layer_selection_container, alignment=Qt.AlignTop)
+        self.layout.addWidget(axes_container, alignment=Qt.AlignTop)
+        self.layout.addWidget(cluster_container, alignment=Qt.AlignTop)
+        self.layout.addWidget(update_container, alignment=Qt.AlignTop)
+        self.layout.addWidget(run_container, alignment=Qt.AlignTop)
+        self.layout.setSpacing(0)
 
         # go through all widgets and change spacing
-        for i in range(self.layout().count()):
-            item = self.layout().itemAt(i).widget()
+        for i in range(self.layout.count()):
+            item = self.layout.itemAt(i).widget()
             item.layout().setSpacing(0)
             item.layout().setContentsMargins(3, 3, 3, 3)
 


### PR DESCRIPTION
This PR should close #182.

- It fixes the bug that makes axes labels not visible when the plot is made for the first time before resizing the widget.
- It changes saved figure's background to white from transparent one.
- It adds a scrollbar to the plotter widget.
- It adds constrained_layout=True when creating the figure, which is a solver that adjusts axes sizes.

I would appreciate some testing on laptops with different display settings @zoccoler @haesleinhuepf 

E.g. here is how it would look like when the widget is put to the top of napari:
![image](https://user-images.githubusercontent.com/52177660/223464338-252632e8-24e6-4f0f-95d8-6098f26322cf.png)