### PR TITLE
Support non sequential label images and unsorted measurements

### DIFF
--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -401,7 +401,7 @@ class PlotterWidget(QWidget):
                             for i in range(int(max_timepoint))
                         ]
                     else:
-                        label_id_lists_per_timepoint = [
+                        label_id_list_per_timepoint = [
                             features[plot_cluster_name].tolist()
                             for i in range(self.analysed_layer.data.shape[0])
                         ]

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -328,6 +328,7 @@ class PlotterWidget(QWidget):
         ):
             # fill all prediction nan values with -1 -> turns them
             # into noise points
+            self.label_ids = features['label']
             self.cluster_ids = features[plot_cluster_name].fillna(-1)
 
             # get long colormap from function
@@ -389,7 +390,12 @@ class PlotterWidget(QWidget):
                 if len(self.analysed_layer.data.shape) == 4:
                     if not tracking_data:
                         max_timepoint = features[POINTER].max() + 1
-
+                        label_id_list_per_timepoint = [
+                            features.loc[features[POINTER] == i][
+                                'label'
+                            ].tolist()
+                            for i in range(int(max_timepoint))
+                        ]
                         prediction_lists_per_timepoint = [
                             features.loc[features[POINTER] == i][
                                 plot_cluster_name
@@ -397,18 +403,22 @@ class PlotterWidget(QWidget):
                             for i in range(int(max_timepoint))
                         ]
                     else:
+                        label_id_lists_per_timepoint = [
+                            features[plot_cluster_name].tolist()
+                            for i in range(self.analysed_layer.data.shape[0])
+                        ]
                         prediction_lists_per_timepoint = [
                             features[plot_cluster_name].tolist()
                             for i in range(self.analysed_layer.data.shape[0])
                         ]
 
                     cluster_image = dask_cluster_image_timelapse(
-                        self.analysed_layer.data, prediction_lists_per_timepoint
+                        self.analysed_layer.data, label_id_list_per_timepoint, prediction_lists_per_timepoint
                     )
 
                 elif len(self.analysed_layer.data.shape) <= 3:
                     cluster_image = generate_cluster_image(
-                        self.analysed_layer.data, self.cluster_ids
+                        self.analysed_layer.data, self.label_ids, self.cluster_ids
                     )
                 else:
                     warnings.warn("Image dimensions too high for processing!")

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -328,7 +328,7 @@ class PlotterWidget(QWidget):
         ):
             # fill all prediction nan values with -1 -> turns them
             # into noise points
-            self.label_ids = features['label']
+            self.label_ids = features["label"]
             self.cluster_ids = features[plot_cluster_name].fillna(-1)
 
             # get long colormap from function
@@ -391,9 +391,7 @@ class PlotterWidget(QWidget):
                     if not tracking_data:
                         max_timepoint = features[POINTER].max() + 1
                         label_id_list_per_timepoint = [
-                            features.loc[features[POINTER] == i][
-                                'label'
-                            ].tolist()
+                            features.loc[features[POINTER] == i]["label"].tolist()
                             for i in range(int(max_timepoint))
                         ]
                         prediction_lists_per_timepoint = [
@@ -413,7 +411,9 @@ class PlotterWidget(QWidget):
                         ]
 
                     cluster_image = dask_cluster_image_timelapse(
-                        self.analysed_layer.data, label_id_list_per_timepoint, prediction_lists_per_timepoint
+                        self.analysed_layer.data,
+                        label_id_list_per_timepoint,
+                        prediction_lists_per_timepoint,
                     )
 
                 elif len(self.analysed_layer.data.shape) <= 3:

--- a/napari_clusters_plotter/_tests/test_utils.py
+++ b/napari_clusters_plotter/_tests/test_utils.py
@@ -61,7 +61,9 @@ def test_cluster_image_generation():
 
     label_id_list = np.array([[1, 2, 3, 4, 5, 6, 7], [1, 2, 3, 4, 5, 6, 7]])
     predictions_list = np.array([[0, 0, 0, 1, 1, 1, 2], [0, 0, 0, 1, 1, 1, 0]])
-    result_dask = dask_cluster_image_timelapse(label_timelapse, label_id_list, predictions_list)
+    result_dask = dask_cluster_image_timelapse(
+        label_timelapse, label_id_list, predictions_list
+    )
     true_result_tp2 = np.array(
         [
             [0, 0, 0, 0, 0, 0, 0],
@@ -76,7 +78,6 @@ def test_cluster_image_generation():
 
     assert np.array_equal(result_dask[0].compute()[0], true_result)
     assert np.array_equal(result_dask[1].compute()[0], true_result_tp2)
-
 
 
 def test_cluster_image_generation_unsorted_non_sequential_labels():
@@ -113,7 +114,9 @@ def test_cluster_image_generation_unsorted_non_sequential_labels():
 
     label_id_list = np.array([[1, 2, 9, 8, 5, 6, 7], [1, 2, 9, 8, 5, 6, 7]])
     predictions_list = np.array([[0, 0, 0, 1, 1, 1, 2], [0, 0, 0, 1, 1, 1, 0]])
-    result_dask = dask_cluster_image_timelapse(label_timelapse, label_id_list, predictions_list)
+    result_dask = dask_cluster_image_timelapse(
+        label_timelapse, label_id_list, predictions_list
+    )
     true_result_tp2 = np.array(
         [
             [0, 0, 0, 0, 0, 0, 0],
@@ -128,7 +131,6 @@ def test_cluster_image_generation_unsorted_non_sequential_labels():
 
     assert np.array_equal(result_dask[0].compute()[0], true_result)
     assert np.array_equal(result_dask[1].compute()[0], true_result_tp2)
-
 
 
 def test_feature_setting(make_napari_viewer):

--- a/napari_clusters_plotter/_tests/test_utils.py
+++ b/napari_clusters_plotter/_tests/test_utils.py
@@ -78,6 +78,59 @@ def test_cluster_image_generation():
     assert np.array_equal(result_dask[1].compute()[0], true_result_tp2)
 
 
+
+def test_cluster_image_generation_unsorted_non_sequential_labels():
+    label = np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 1, 0, 0, 2, 2],
+            [0, 0, 0, 0, 2, 2, 2],
+            [8, 8, 0, 0, 0, 0, 0],
+            [0, 0, 9, 9, 0, 5, 5],
+            [6, 6, 6, 6, 0, 5, 0],
+            [0, 7, 7, 0, 0, 0, 0],
+        ]
+    )
+
+    label_ids = np.array([1, 2, 9, 8, 5, 6, 7])
+    predictions = np.array([0, 0, 0, 1, 1, 1, 2])
+    result = generate_cluster_image(label, label_ids, predictions)
+    true_result = np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 1, 0, 0, 1, 1],
+            [0, 0, 0, 0, 1, 1, 1],
+            [2, 2, 0, 0, 0, 0, 0],
+            [0, 0, 1, 1, 0, 2, 2],
+            [2, 2, 2, 2, 0, 2, 0],
+            [0, 3, 3, 0, 0, 0, 0],
+        ]
+    )
+    assert np.array_equal(result, true_result)
+
+    label_timelapse_3d = np.array([label, label])
+    label_timelapse = reshape_2D_timelapse(label_timelapse_3d)
+
+    label_id_list = np.array([[1, 2, 9, 8, 5, 6, 7], [1, 2, 9, 8, 5, 6, 7]])
+    predictions_list = np.array([[0, 0, 0, 1, 1, 1, 2], [0, 0, 0, 1, 1, 1, 0]])
+    result_dask = dask_cluster_image_timelapse(label_timelapse, label_id_list, predictions_list)
+    true_result_tp2 = np.array(
+        [
+            [0, 0, 0, 0, 0, 0, 0],
+            [0, 1, 1, 0, 0, 1, 1],
+            [0, 0, 0, 0, 1, 1, 1],
+            [2, 2, 0, 0, 0, 0, 0],
+            [0, 0, 1, 1, 0, 2, 2],
+            [2, 2, 2, 2, 0, 2, 0],
+            [0, 1, 1, 0, 0, 0, 0],
+        ]
+    )
+
+    assert np.array_equal(result_dask[0].compute()[0], true_result)
+    assert np.array_equal(result_dask[1].compute()[0], true_result_tp2)
+
+
+
 def test_feature_setting(make_napari_viewer):
     viewer = make_napari_viewer()
     label = np.array(

--- a/napari_clusters_plotter/_tests/test_utils.py
+++ b/napari_clusters_plotter/_tests/test_utils.py
@@ -40,8 +40,9 @@ def test_cluster_image_generation():
         ]
     )
 
+    label_ids = np.array([1, 2, 3, 4, 5, 6, 7])
     predictions = np.array([0, 0, 0, 1, 1, 1, 2])
-    result = generate_cluster_image(label, predictions)
+    result = generate_cluster_image(label, label_ids, predictions)
     true_result = np.array(
         [
             [0, 0, 0, 0, 0, 0, 0],
@@ -58,8 +59,9 @@ def test_cluster_image_generation():
     label_timelapse_3d = np.array([label, label])
     label_timelapse = reshape_2D_timelapse(label_timelapse_3d)
 
+    label_id_list = np.array([[1, 2, 3, 4, 5, 6, 7], [1, 2, 3, 4, 5, 6, 7]])
     predictions_list = np.array([[0, 0, 0, 1, 1, 1, 2], [0, 0, 0, 1, 1, 1, 0]])
-    result_dask = dask_cluster_image_timelapse(label_timelapse, predictions_list)
+    result_dask = dask_cluster_image_timelapse(label_timelapse, label_id_list, predictions_list)
     true_result_tp2 = np.array(
         [
             [0, 0, 0, 0, 0, 0, 0],

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -271,7 +271,9 @@ def dask_cluster_image_timelapse(label_image, label_id_list, prediction_list_lis
     lazy_cluster_image = delayed(generate_cluster_image)  # lazy processor
     lazy_arrays = [
         lazy_cluster_image(frame, labels_ids, preds)
-        for frame, labels_ids, preds in zip(label_image, label_id_list, prediction_list_list)
+        for frame, labels_ids, preds in zip(
+            label_image, label_id_list, prediction_list_list
+        )
     ]
     dask_arrays = [
         da.from_delayed(delayed_reader, shape=sample.shape, dtype=sample.dtype)

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -233,6 +233,7 @@ def generate_cluster_image(label_image, label_list, predictionlist):
     # for cluster labels that start at 0, conveniently hdbscan
     # labelling starts at -1 for noise, removing these from the labels
     predictionlist_new = np.array(predictionlist) + 1
+    label_list = np.array(label_list)
 
     return map_array(label_image, label_list, predictionlist_new).astype("uint64")
 


### PR DESCRIPTION
Hi Laura @lazigu , hi Mara @marabuuu ,

similar to [recent changes](https://github.com/haesleinhuepf/napari-skimage-regionprops/pull/67) in napari-skimage-regionprops, I'm adding support for unsorted measurements and non-sequential label images here. The trick is to use `skimage.utils.map_array` and this requires to have a list of label IDs for the corresponding predictions.

A python-test was added to see if it works on normal images and on timelapse-data. I also checked that it works from the GUI, but only tested the normal-image case with blobs.gif. Would you mind testing it again, also with timelapse data, to be sure that I didn't screw anything up?

Big thanks!

Best,
Robert