### PR TITLE
remove list conversion

### DIFF
--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -234,7 +234,7 @@ def generate_cluster_image(label_image, predictionlist):
     # labelling starts at -1 for noise, removing these from the labels
     predictionlist_new = np.array(predictionlist) + 1
 
-    return relabel(label_image, list(predictionlist_new)).astype("uint64")
+    return relabel(label_image, predictionlist_new).astype("uint64")
 
 
 def dask_cluster_image_timelapse(label_image, prediction_list_list):


### PR DESCRIPTION
Hi,

this PR removes a unnecessary list conversion in this line:

https://github.com/BiAPoL/napari-clusters-plotter/blob/7cb12772595ac75bf9c45fb9804d7d0f657eab47/napari_clusters_plotter/_utilities.py#L237

Because the relabel function just calls either this method:

https://github.com/haesleinhuepf/napari-skimage-regionprops/blob/a190019fa7e98abcbd7755af1bcb81aeea22610e/napari_skimage_regionprops/_parametric_images.py#L175-L177

or this method:
https://github.com/haesleinhuepf/napari-skimage-regionprops/blob/a190019fa7e98abcbd7755af1bcb81aeea22610e/napari_skimage_regionprops/_parametric_images.py#L180-L181

And both methods convert them again to numpy arrays!

This is not only a waste of memory, but especially waste of computational time.

This alone reduces the runtime of the "run" method (2D histogram) for a dataset with 35 Million datapoints from 31 seconds to 25 seconds (20% speedup). I've more improvements that brings it down to 8 seconds, but first #196 needs be merged, as I don't want to add more commits to this branch :-)

Best,
Thorsten
