### PR TITLE
Don't reset zoom on redraw

### DIFF
--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -457,7 +457,7 @@ class MplCanvas(FigureCanvas):
         self.xylim = None
 
         super().__init__(self.fig)
-        self.mpl_connect('draw_event', self.on_draw)
+        self.mpl_connect("draw_event", self.on_draw)
         # polygons for 2d histogram
         self.polygons = []
         self.pts = self.axes.scatter([], [])
@@ -482,7 +482,6 @@ class MplCanvas(FigureCanvas):
 
     def on_draw(self, event):
         self.xylim = (self.axes.get_xlim(), self.axes.get_ylim())
-
 
     def draw_rectangle(self, eclick, erelease):
         """eclick and erelease are the press and release events"""

--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -454,8 +454,10 @@ class MplCanvas(FigureCanvas):
         self.histogram = None
 
         self.match_napari_layout()
+        self.xylim = None
 
         super().__init__(self.fig)
+        self.mpl_connect('draw_event', self.on_draw)
         # polygons for 2d histogram
         self.polygons = []
         self.pts = self.axes.scatter([], [])
@@ -472,6 +474,15 @@ class MplCanvas(FigureCanvas):
             interactive=False,
         )
         self.reset()
+
+    def reset_zoom(self):
+        if self.xylim:
+            self.axes.set_xlim(self.xylim[0])
+            self.axes.set_ylim(self.xylim[1])
+
+    def on_draw(self, event):
+        self.xylim = (self.axes.get_xlim(), self.axes.get_ylim())
+
 
     def draw_rectangle(self, eclick, erelease):
         """eclick and erelease are the press and release events"""

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -184,7 +184,6 @@ class PlotterWidget(QMainWindow):
                 clustering_ID = self.cluster_ids.name
                 features = get_layer_tabular_data(self.analysed_layer)
 
-
             features = get_layer_tabular_data(self.analysed_layer)
 
             # redraw the whole plot

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -717,3 +717,4 @@ class PlotterWidget(QMainWindow):
 
             self.graphics_widget.draw()  # Only redraws when cluster is not manually selected
             # because manual selection already does that when selector is disconnected
+        self.graphics_widget.reset_zoom()


### PR DESCRIPTION
This PR should be merged after #196 was merged.

When you want to selected multiple clusters and use the zoom tool its quite annoying that it always resets the zoom afterwards:
![reset_zoom](https://user-images.githubusercontent.com/1113977/225939376-6d92d835-3664-4409-9947-7190d41d6d6a.gif)

This PR fixes that issue. The zoom is not reset after you for example draw a cluster:
![no_reset_zoom](https://user-images.githubusercontent.com/1113977/225939496-52b006b4-37e8-4aa8-bc2b-b82fdf92e124.gif)

Most of the commits come from #196 - this is the only relevant  change: https://github.com/BiAPoL/napari-clusters-plotter/pull/214/commits/6b703c827b75feb6c38cec8145aaad7b2d48fd1a
