### PR TITLE
Pin numpy version due to incompatibility with numba

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,11 @@ packages = find:
 python_requires = >=3.7
 
 # add your package requirements here
+# remove pinned numpy version after incompatibility with numba is fixed
+# see here https://github.com/BiAPoL/napari-clusters-plotter/issues/215
 install_requires =
     napari-plugin-engine>=0.1.4
-    numpy>=1.21
+    numpy>=1.21,<=1.23.5
     scikit-learn
     matplotlib
     pandas


### PR DESCRIPTION
See #215
The issue will be renamed, but not closed to not forget to remove the pinned version when the problem is fixed.