### PR TITLE
Update tests workflow file (disable tests on windows, update versions, use codecov token)

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
+        platform: [ubuntu-latest, macos-latest] # windows-latest (disabled, see related issue)
         python-version: [3.8, 3.9]
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -85,7 +85,9 @@ jobs:
         run: pytest -v --cov=./ --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   deploy:
     # this will run when you have tagged a commit, starting with "v*"
@@ -95,7 +97,7 @@ jobs:
     runs-on: ubuntu-latest
     if: contains(github.ref, 'tags')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
         uses: actions/setup-python@v2
         with:


### PR DESCRIPTION
Currently, our GitHub actions on Windows fail due to a segmentation fault ([see this workflow run](https://github.com/BiAPoL/napari-clusters-plotter/actions/runs/4541784803)), or the screenshot:
![image](https://user-images.githubusercontent.com/52177660/228332575-b5b27eae-cbba-4041-ba70-14dedccc3121.png)

I have no idea what caused it, because it happens for branches that had successful checks a few days ago, and were not changed since then. Since I have no idea where the problem lies, and how to fix it, I will disable tests on Windows via GitHub actions, and create an issue as a reminder to enable them again when/if the problem is fixed.

In addition, I have added a codecov token due to [this issue](https://github.com/codecov/codecov-action/issues/557).