### PR TITLE
Coloring by features as well as cluster

### DIFF
--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -225,11 +225,11 @@ class PlotterWidget(QMainWindow):
                 self.bin_number_container.setVisible(True)
                 self.log_scale_container.setVisible(True)
                 self.plot_hide_non_selected.setChecked(True)
-                self.colormap_container.setVisible(True)
+                # self.colormap_container.setVisible(True)
             else:
                 self.bin_number_container.setVisible(False)
                 self.log_scale_container.setVisible(False)
-                self.colormap_container.setVisible(False) 
+                # self.colormap_container.setVisible(False) 
             replot()
 
         def bin_number_set():
@@ -314,7 +314,7 @@ class PlotterWidget(QMainWindow):
             options={"choices": list(ALL_COLORMAPS.keys())},
             label="Colormap",
         )
-        self.colormap_container.setVisible(False)
+        self.colormap_container.setVisible(True)
         self.colormap_dropdown.native.currentIndexChanged.connect(replot)
         self.advanced_options_container.layout().addWidget(self.colormap_container)
 
@@ -806,6 +806,9 @@ class PlotterWidget(QMainWindow):
             self.graphics_widget.axes.set_ylabel(plot_y_axis_name)
         
             keep_selection = list(self.viewer.layers.selection)
+
+            self.graphics_widget.match_napari_layout()
+            
             if redraw_cluster_image:
                 # depending on the dimensionality of the data
                 # generate the feature image
@@ -827,6 +830,7 @@ class PlotterWidget(QMainWindow):
                                                             scale=self.analysed_layer.scale,
                                                             )
                     else:
+                        # Making sure that the feature visualisation layer is on top
                         if self.viewer.layers[-1] != self.visualized_feature_layer:
                             for i,layer in enumerate(self.viewer.layers):
                                 if layer == self.visualized_feature_layer:

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -770,15 +770,11 @@ class PlotterWidget(QMainWindow):
             and plot_cluster_name in list(features.keys())
             and "CLUSTER" not in plot_cluster_name
         ):
-            ################
-            # INITIALISATION
             if self.plotting_type.currentText() != PlottingType.SCATTER.name:
                 warnings.warn(
                     "Feature Visualisation Only Availible in Scatter Plot!"
                 )
                 return
-
-            self.label_ids = features["label"]
             feature_values = features[plot_cluster_name].fillna(0)
 
             # Determine Current Frame
@@ -810,11 +806,9 @@ class PlotterWidget(QMainWindow):
             self.graphics_widget.axes.set_ylabel(plot_y_axis_name)
         
             keep_selection = list(self.viewer.layers.selection)
-
-                
             if redraw_cluster_image:
                 # depending on the dimensionality of the data
-                # generate the cluster image
+                # generate the feature image
                 if len(self.analysed_layer.data.shape) > 4:
                     warnings.warn("Image dimensions too high for processing!")
                     return

--- a/napari_clusters_plotter/_plotter_utilities.py
+++ b/napari_clusters_plotter/_plotter_utilities.py
@@ -393,7 +393,7 @@ def colors_feature(feature_values, frame_id, current_frame, continuous_cmap):
     Returns
     -------
     list
-        A list of hex color codes for each data point based on the cluster they belong to.
+        A list of hex color codes for each data point based on the feature values of the points.
         The color of the data point at the current frame is highlighted.
     """
     scaled_values = scale_array(feature_values)

--- a/napari_clusters_plotter/_plotter_utilities.py
+++ b/napari_clusters_plotter/_plotter_utilities.py
@@ -1,6 +1,7 @@
 import typing
-import matplotlib as mpl
+
 import matplotlib
+import matplotlib as mpl
 import numpy as np
 import pandas as pd
 from matplotlib.colors import to_hex, to_rgb
@@ -93,6 +94,7 @@ def clustered_plot_parameters(
     )
     return a, s, c
 
+
 def feature_plot_parameters(
     feature_values: list,
     frame_id: list,
@@ -139,6 +141,7 @@ def feature_plot_parameters(
         mpl_colormap,
     )
     return a, s, c
+
 
 def alphas_clustered(
     cluster_id: list, frame_id: list, current_frame: int, n_datapoints: int
@@ -309,6 +312,7 @@ def estimate_number_bins(data) -> int:
         return 256
     return int(est_a)
 
+
 def colors_clustered(cluster_id, frame_id, current_frame, color_hex_list):
     """
     Calculates the size of each data point in a clustered visualization.
@@ -373,6 +377,7 @@ def colors_unclustered(frame_id, current_frame):
         colors = [highlight if tp == current_frame else grey for tp in frame_id]
         return colors
 
+
 def colors_feature(feature_values, frame_id, current_frame, continuous_cmap):
     """
     Calculates the size of each data point in a clustered visualization.
@@ -409,6 +414,7 @@ def colors_feature(feature_values, frame_id, current_frame, continuous_cmap):
         for x, tp in zip(scaled_values, frame_id)
     ]
     return colors
+
 
 def initial_and_noise_alpha():
     """
@@ -649,17 +655,18 @@ def make_cluster_overlay_img(
 
     return cluster_overlay_rgba.swapaxes(0, 1)
 
-def scale_array(arr,percentile = 1):
+
+def scale_array(arr, percentile=1):
     """
     Scales an input array between 0 and 1 using percentiles.
-    
+
     Parameters:
     arr (numpy.ndarray): The input array to scale.
-    
+
     Returns:
     numpy.ndarray: The scaled array.
     """
-    p1, p99 = np.percentile(arr, (percentile, 100-percentile))
+    p1, p99 = np.percentile(arr, (percentile, 100 - percentile))
     scaled_arr = (arr - p1) / (p99 - p1)
     scaled_arr = np.clip(scaled_arr, 0, 1)
     return scaled_arr


### PR DESCRIPTION
This PR will address #209. Currently I have implemented it so that the features are also available in the dropdown for cluster ID and the colormap can be selected even when in scatterplot mode. 

When features are plotted a feature layer is created. One problem was that this layer can be hidden if a cluster layer is created afterwards and vice versa. My way of solving this problem is to keep the feature layer as the top layer and changing the visibility of the layers for feature or cluster visualization depending on what is plotted. I'm not sure if this is the best solution and would be grateful if anyone tests it.

Furthermore, we would have to add a colorbar so that the colors for the features can be interpreted. 

I would be happy if someone would take a look at the code or try it out as it does add quite a few lines, but I could not think of a more elegant solution without rewriting a lot of the other code..

Anyway here is a small video demonstrating how it works at the moment:
https://github.com/BiAPoL/napari-clusters-plotter/assets/65285466/153a0d8d-a21a-450b-9b4e-88fde6926cd7

