### PR TITLE
added explicit dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,7 +48,7 @@ install_requires =
     napari-skimage-regionprops>=0.3.1
     hdbscan
     qtpy
-    dask-core
+    dask
     napari
     magicgui
     scikit-image

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,13 @@ install_requires =
     napari-tools-menu
     napari-skimage-regionprops>=0.3.1
     hdbscan
-    joblib
+    qtpy
+    dask-core
+    napari
+    magicgui
+    scikit-image
+    superqt
+    scipy
 
 
 [options.entry_points]


### PR DESCRIPTION
#268 

This adds a few dependencies to the `setup.cfg` that are, according to @goanpeca, imported in the plugin but not explicitly declared in the dependencies. Examples are, for instance, `magicgui, `scikit-image` and `scipy`, all of which are dependencies of napari and thus not explicitly declared although they should be.