### PR TITLE
fix opacity adjustment and set it to low non-zero value

### DIFF
--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -124,7 +124,7 @@ class PlotterWidget(QMainWindow):
                 plot_cluster_name=clustering_ID,
             )
             if isinstance(self.analysed_layer, Labels):
-                self.layer_select.value.opacity = 0
+                self.layer_select.opacity = 0.1
 
         # Canvas Widget that displays the 'figure', it takes the 'figure' instance
         self.graphics_widget = MplCanvas(

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -124,7 +124,7 @@ class PlotterWidget(QMainWindow):
                 plot_cluster_name=clustering_ID,
             )
             if isinstance(self.analysed_layer, Labels):
-                self.layer_select.opacity = 0.1
+                self.layer_select.opacity = 0.2
 
         # Canvas Widget that displays the 'figure', it takes the 'figure' instance
         self.graphics_widget = MplCanvas(


### PR DESCRIPTION
This should fix #279 and could potentially solve #271 .

This lets the selected layer barely visible (`opacity = 0.2`), which would not lead (I think) to the user thinking the original labels layer was broken, but still hide it quite a bit so that the clustering result does not blend much with the labels colors.

The best option in my opinion is to interactively hide and show it, which is already written in the documentation [under **Manual clustering**](https://github.com/BiAPoL/napari-clusters-plotter/blob/main/README.md#manual-clustering).

Diving deep into git blame, it seems this was set by @thorstenwagner [here](https://github.com/BiAPoL/napari-clusters-plotter/commit/02785e662728cdd6f61b70cc5341b768b2fda048), which then was later updated to setting opacity to `0`. @thorstenwagner,  would it be OK for your use cases to let a small opacity like `0.2`?

Best,
Marcelo