### PR TITLE
Don't recalcuate histogram if not necessary

### DIFF
--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -592,8 +592,11 @@ class MplCanvas(FigureCanvas):
         norm = None
         if log_scale:
             norm = "log"
-        if self.histogram is not None and np.array_equal(self.last_datax, data_x) and np.array_equal(self.last_datay,
-                                                                                                     data_y):
+        if (
+            self.histogram is not None
+            and np.array_equal(self.last_datax, data_x)
+            and np.array_equal(self.last_datay, data_y)
+        ):
             (h, xedges, yedges) = self.histogram
         else:
             h, xedges, yedges = np.histogram2d(data_x, data_y, bins=bin_number)


### PR DESCRIPTION
Hi,

I'm making great use of this plugin, but if data gets huge (like 32 million datapoints) it becomes much slower.

For example, after the umap is loaded and I circle a cluster it takes like 17 seconds to highlight the clusters.

This is the first PR to improve this. With the proposed changes, the 2dhistogram is not recalculated if the data hasn't changed.

It already reduces the computational time from 17 seconds to like 12 seconds.

Seconds PR follows :-) 

Best,
Thorsten