### PR TITLE
Speed-up generate cluster image

### DIFF
--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -528,6 +528,8 @@ class MplCanvas(FigureCanvas):
         self.match_napari_layout()
         self.xylim = None
         self.last_xy_labels = None
+        self.last_datax = None
+        self.last_datay = None
 
         super().__init__(self.fig)
         self.mpl_connect("draw_event", self.on_draw)
@@ -590,7 +592,14 @@ class MplCanvas(FigureCanvas):
         norm = None
         if log_scale:
             norm = "log"
-        h, xedges, yedges = np.histogram2d(data_x, data_y, bins=bin_number)
+        if self.histogram is not None and np.array_equal(self.last_datax, data_x) and np.array_equal(self.last_datay,
+                                                                                                     data_y):
+            (h, xedges, yedges) = self.histogram
+        else:
+            h, xedges, yedges = np.histogram2d(data_x, data_y, bins=bin_number)
+            self.last_datax = data_x
+            self.last_datay = data_y
+
         self.axes.imshow(
             h.T,
             extent=[xedges[0], xedges[-1], yedges[0], yedges[-1]],

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -300,12 +300,10 @@ def generate_cluster_image(label_image, label_list, predictionlist):
 
     # label_list can be removed from method.
     predictionlist_new = np.array(predictionlist) + 1
-    plist = np.zeros(np.max(label_image)+1,dtype=np.uint32)
+    plist = np.zeros(np.max(label_image) + 1, dtype=np.uint32)
     plist[label_list] = predictionlist_new
 
     predictionlist_new = plist
-
-
 
     return predictionlist_new[label_image]
 

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -299,8 +299,13 @@ def generate_cluster_image(label_image, label_list, predictionlist):
     """
 
     # label_list can be removed from method.
-
     predictionlist_new = np.array(predictionlist) + 1
+    plist = np.zeros(np.max(label_image)+1,dtype=np.uint32)
+    plist[label_list] = predictionlist_new
+
+    predictionlist_new = plist
+
+
 
     return predictionlist_new[label_image].astype(
         "uint32"

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -297,15 +297,12 @@ def generate_cluster_image(label_image, label_list, predictionlist):
     ----------
     ndarray: The clusters image as a numpy array.
     """
-    from skimage.util import map_array
 
-    # reforming the prediction list, this is done to account
-    # for cluster labels that start at 0, conveniently hdbscan
-    # labelling starts at -1 for noise, removing these from the labels
+    # label_list can be remove from method.
+
     predictionlist_new = np.array(predictionlist) + 1
-    label_list = np.array(label_list)
 
-    return map_array(np.asarray(label_image), label_list, predictionlist_new).astype(
+    return predictionlist_new[label_image].astype(
         "uint32"
     )
 

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -307,9 +307,7 @@ def generate_cluster_image(label_image, label_list, predictionlist):
 
 
 
-    return predictionlist_new[label_image].astype(
-        "uint32"
-    )
+    return predictionlist_new[label_image].astype("uint32")
 
 
 def generate_cluster_surface(surface_data, prediction_list):

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -307,7 +307,7 @@ def generate_cluster_image(label_image, label_list, predictionlist):
 
 
 
-    return predictionlist_new[label_image].astype("uint32")
+    return predictionlist_new[label_image]
 
 
 def generate_cluster_surface(surface_data, prediction_list):

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -298,7 +298,7 @@ def generate_cluster_image(label_image, label_list, predictionlist):
     ndarray: The clusters image as a numpy array.
     """
 
-    # label_list can be remove from method.
+    # label_list can be removed from method.
 
     predictionlist_new = np.array(predictionlist) + 1
 


### PR DESCRIPTION
The generate_cluster_image method is the most computationally intensive part when working with large data like mine (32 million data points). As already written in #282, the total time from circling a cluster to visualizing the highlighted cluster is 17 seconds for my data.

This PR reduces it by another 6 seconds, and thus together with PR #282 from 17 seconds to 6 seconds - which is a much better user experience.

The PR works beautifully on my data, but I'm a bit skeptical that it will work with other workflows. So it would require some testing on your part :-) 

Please let me know your thoughts!

Best,
Thorsten