### PR TITLE
Convert max label to integer before using it as parameter for np.zeros

### DIFF
--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -300,7 +300,7 @@ def generate_cluster_image(label_image, label_list, predictionlist):
 
     # label_list can be removed from method.
     predictionlist_new = np.array(predictionlist) + 1
-    plist = np.zeros(np.max(label_image) + 1, dtype=np.uint32)
+    plist = np.zeros(int(np.max(label_image)) + 1, dtype=np.uint32)
     plist[label_list] = predictionlist_new
 
     predictionlist_new = plist


### PR DESCRIPTION
This PR fixes a the following exception:

![grafik](https://github.com/BiAPoL/napari-clusters-plotter/assets/10515534/f48e5645-de4d-4ca0-a76d-9f8a88f99cce)

which was raised after this workflow:

![GIF 11 12 2023 15-23-57](https://github.com/BiAPoL/napari-clusters-plotter/assets/10515534/22471fb6-5718-4c87-8394-edd654099315)

The consequence of the exception was that no cluster_ids_in_space layer was generated after making a freehand selection in the clusters plotter.