### PR TITLE
Update method generate_cluster_tracks()

### DIFF
--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -240,18 +240,20 @@ def update_properties_list(widget, exclude_list):
 
 
 def generate_cluster_tracks(analysed_layer, plot_cluster_name):
+
     features = analysed_layer.features
-    label_id_list_per_timepoint = [
-        features["label"].tolist() for i in range(analysed_layer.data.shape[0])
-    ]
-    prediction_lists_per_timepoint = [
-        features[plot_cluster_name].tolist()
-        for i in range(analysed_layer.data.shape[0])
-    ]
+    label_id_lists_per_timepoint = list()
+    prediction_lists_per_timepoint = list()
+
+    for i in range(analysed_layer.data.shape[0]):
+        labels_of_timeframe = np.unique(analysed_layer.data[i].flatten())
+        filtered_features = features[features["label"].isin(labels_of_timeframe)]
+        label_id_lists_per_timepoint.append(filtered_features["label"].tolist())
+        prediction_lists_per_timepoint.append(filtered_features[plot_cluster_name].tolist())
 
     cluster_data = dask_cluster_image_timelapse(
         analysed_layer.data,
-        label_id_list_per_timepoint,
+        label_id_lists_per_timepoint,
         prediction_lists_per_timepoint,
     )
 
@@ -313,6 +315,7 @@ def generate_cluster_image(label_image, label_list, predictionlist):
     Generates a clusters image from a label image and a list of cluster predictions,
     where each label value corresponds to the cluster identity.
     It is assumed that len(predictionlist) == max(label_image)
+    This function is recommended instead of generate_cluster_image_ as it is faster, because it does not use skimage.util.map_array
 
     Parameters
     ----------
@@ -327,9 +330,7 @@ def generate_cluster_image(label_image, label_list, predictionlist):
     """
 
     predictionlist_new = np.array(predictionlist) + 1
-    plist = np.zeros(
-        int(max([label_image.max(), np.max(label_list)])) + 1, dtype=np.uint32
-    )
+    plist = np.zeros(int(np.max(label_image)) + 1, dtype=np.uint32)
     plist[label_list] = predictionlist_new
 
     predictionlist_new = plist

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -340,8 +340,8 @@ def generate_cluster_image(label_image, label_list, predictionlist):
         # we take the maximum of either the labels in the image
         # or the labels in the list to take care of the case, where
         # the label list contains labels not in the image
-        int(max([label_image.max(), np.max(label_list)])) + 1, 
-        dtype=np.uint32
+        int(max([label_image.max(), np.max(label_list)])) + 1,
+        dtype=np.uint32,
     )
     plist[label_list] = predictionlist_new
 

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -240,7 +240,6 @@ def update_properties_list(widget, exclude_list):
 
 
 def generate_cluster_tracks(analysed_layer, plot_cluster_name):
-
     features = analysed_layer.features
     label_id_lists_per_timepoint = list()
     prediction_lists_per_timepoint = list()
@@ -249,7 +248,9 @@ def generate_cluster_tracks(analysed_layer, plot_cluster_name):
         labels_of_timeframe = np.unique(analysed_layer.data[i].flatten())
         filtered_features = features[features["label"].isin(labels_of_timeframe)]
         label_id_lists_per_timepoint.append(filtered_features["label"].tolist())
-        prediction_lists_per_timepoint.append(filtered_features[plot_cluster_name].tolist())
+        prediction_lists_per_timepoint.append(
+            filtered_features[plot_cluster_name].tolist()
+        )
 
     cluster_data = dask_cluster_image_timelapse(
         analysed_layer.data,

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -245,7 +245,7 @@ def generate_cluster_tracks(analysed_layer, plot_cluster_name):
     prediction_lists_per_timepoint = list()
 
     for i in range(analysed_layer.data.shape[0]):
-        labels_of_timeframe = np.unique(analysed_layer.data[i].flatten())
+        labels_of_timeframe = np.unique(analysed_layer.data[i])
         filtered_features = features[features["label"].isin(labels_of_timeframe)]
         label_id_lists_per_timepoint.append(filtered_features["label"].tolist())
         prediction_lists_per_timepoint.append(

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -287,6 +287,9 @@ def generate_cluster_image_(label_image, label_list, predictionlist):
     Generates a clusters image from a label image and a list of cluster predictions,
     where each label value corresponds to the cluster identity.
     It is assumed that len(predictionlist) == max(label_image)
+
+    Deprecated, use generate_cluster_image instead
+
     Parameters
     ----------
     label_image: ndarray or dask array
@@ -316,7 +319,9 @@ def generate_cluster_image(label_image, label_list, predictionlist):
     Generates a clusters image from a label image and a list of cluster predictions,
     where each label value corresponds to the cluster identity.
     It is assumed that len(predictionlist) == max(label_image)
-    This function is recommended instead of generate_cluster_image_ as it is faster, because it does not use skimage.util.map_array
+
+    This function is recommended instead of generate_cluster_image_ as it is faster,
+    because it does not use skimage.util.map_array
 
     Parameters
     ----------

--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -336,7 +336,13 @@ def generate_cluster_image(label_image, label_list, predictionlist):
     """
 
     predictionlist_new = np.array(predictionlist) + 1
-    plist = np.zeros(int(np.max(label_image)) + 1, dtype=np.uint32)
+    plist = np.zeros(
+        # we take the maximum of either the labels in the image
+        # or the labels in the list to take care of the case, where
+        # the label list contains labels not in the image
+        int(max([label_image.max(), np.max(label_list)])) + 1, 
+        dtype=np.uint32
+    )
     plist[label_list] = predictionlist_new
 
     predictionlist_new = plist


### PR DESCRIPTION

* In https://github.com/BiAPoL/napari-clusters-plotter/pull/286#issuecomment-1856420498 it was pointed out that

> The problem is that my method assumes that label_list only contains labels that are actually part of the label_image, which is not the case for your track data. I think it should, and the implementation of `generate_cluster_tracks` may be buggy as it produces the same label_list for each time point, regardless of the actual labels at that time point.

* This PR is dedicated to provide a solution for this:
  * Cluster tracks generates now image specific label and cluster id lists instead of repeating the complete lists containing all labels for all images
  * Generate_cluster_image() does not need to account for that fact anymore