### PR TITLE
Deselect clusters

### DIFF
--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -580,11 +580,7 @@ class MplCanvas(FigureCanvas):
         self.reset()
 
     def set_selector_cluster_id_overlay(self, overlay: np.array):
-        try:
             self.selector.cluster_id_histo_overlay = overlay
-        except:
-            # might not exist...
-            pass
 
     def reset_zoom(self):
         if self.xylim:

--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -418,15 +418,15 @@ class SelectFrom2DHistogram:
         coord = tuple([int(c) for c in v])
         return coord
 
-
     def onselect(self, verts):
-
         if self.parent.manual_clustering_method is None:
             return
 
         modifiers = QGuiApplication.keyboardModifiers()
 
-        if modifiers == Qt.ControlModifier and len(verts)==2: # has len of 2 when single click was done
+        if (
+            modifiers == Qt.ControlModifier and len(verts) == 2
+        ):  # has len of 2 when single click was done
             coord_click = self.vert_to_coord(verts[0])
             cluster_id_to_delete = self.cluster_id_histo_overlay[coord_click[::-1]][0]
             if cluster_id_to_delete > 0:

--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -582,7 +582,7 @@ class MplCanvas(FigureCanvas):
         self.reset()
 
     def set_selector_cluster_id_overlay(self, overlay: np.array):
-            self.selector.cluster_id_histo_overlay = overlay
+        self.selector.cluster_id_histo_overlay = overlay
 
     def reset_zoom(self):
         if self.xylim:

--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -654,7 +654,7 @@ class MplCanvas(FigureCanvas):
         self.histogram = (h, xedges, yedges)
         self.selector.disconnect()
         self.selector = SelectFrom2DHistogram(
-            self, self.axes, full_data, self.histogram
+            self, self.axes, self.full_data, self.histogram
         )
         self.axes.figure.canvas.draw_idle()
 

--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -12,10 +12,8 @@ from matplotlib.figure import Figure
 from matplotlib.path import Path
 from matplotlib.widgets import LassoSelector, RectangleSelector, SpanSelector
 from napari.layers import Image, Layer
-from qtpy.QtCore import QRect
-from qtpy.QtCore import Qt
-from qtpy.QtGui import QGuiApplication
-from qtpy.QtGui import QIcon
+from qtpy.QtCore import QRect, Qt
+from qtpy.QtGui import QGuiApplication, QIcon
 from qtpy.QtWidgets import (
     QAbstractItemView,
     QHBoxLayout,
@@ -405,9 +403,9 @@ class SelectFrom2DHistogram:
         self.ind_mask = []
 
     def vert_to_coord(self, vert):
-        '''
+        """
         Converts verticis to histogram coordinates in pixels
-        '''
+        """
         xrange = self.histogram[1][-1] - self.histogram[1][0]
         yrange = self.histogram[2][-1] - self.histogram[2][0]
         v = (
@@ -428,9 +426,13 @@ class SelectFrom2DHistogram:
             if modifiers == Qt.ControlModifier:
                 # I tried to solve it with self.ax.transData.transform... but it did not work...
                 coord_click = self.vert_to_coord(verts[0])
-                cluster_id_to_delete = self.cluster_id_histo_overlay[coord_click[1],coord_click[0]][0]
-                if cluster_id_to_delete>0:
-                    self.parent.manual_clustering_method(self.ind_mask, delete_cluster=cluster_id_to_delete)
+                cluster_id_to_delete = self.cluster_id_histo_overlay[
+                    coord_click[1], coord_click[0]
+                ][0]
+                if cluster_id_to_delete > 0:
+                    self.parent.manual_clustering_method(
+                        self.ind_mask, delete_cluster=cluster_id_to_delete
+                    )
                 else:
                     self.parent.manual_clustering_method(self.ind_mask)
             else:
@@ -652,7 +654,9 @@ class MplCanvas(FigureCanvas):
 
         full_data = pd.concat([pd.DataFrame(data_x), pd.DataFrame(data_y)], axis=1)
         self.selector.disconnect()
-        self.selector = SelectFrom2DHistogram(self, self.axes, full_data, self.histogram)
+        self.selector = SelectFrom2DHistogram(
+            self, self.axes, full_data, self.histogram
+        )
         self.axes.figure.canvas.draw_idle()
 
     def make_1d_histogram(

--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -433,7 +433,7 @@ class SelectFrom2DHistogram:
                 self.parent.manual_clustering_method(
                     np.zeros(shape=self.xys.shape), delete_cluster=cluster_id_to_delete
                 )
-                return
+            return
 
         path = Path(verts)
         self.ind_mask = path.contains_points(self.xys)

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -90,8 +90,9 @@ class PlotterWidget(QMainWindow):
 
         self.analysed_layer = None
         self.visualized_layer = None
+        self.cluster_id_histo_overlay = None
 
-        def manual_clustering_method(inside):
+        def manual_clustering_method(inside, **kwargs):
             inside = np.array(inside)  # leads to errors sometimes otherwise
 
             if self.analysed_layer is None or len(inside) == 0:
@@ -101,7 +102,12 @@ class PlotterWidget(QMainWindow):
             features = get_layer_tabular_data(self.analysed_layer)
 
             modifiers = QGuiApplication.keyboardModifiers()
-            if modifiers == Qt.ShiftModifier and clustering_ID in features.keys():
+            if 'delete_cluster' in kwargs:
+                features[clustering_ID].mask(
+                    features[clustering_ID]==kwargs['delete_cluster'], other=-1, inplace=True
+                )
+
+            elif modifiers == Qt.ShiftModifier and clustering_ID in features.keys():
                 features[clustering_ID].mask(
                     inside, other=features[clustering_ID].max() + 1, inplace=True
                 )
@@ -677,7 +683,7 @@ class PlotterWidget(QMainWindow):
                         log_scale=self.log_scale.isChecked(),
                     )
 
-                    rgb_img = make_cluster_overlay_img(
+                    rgb_img, self.cluster_id_histo_overlay = make_cluster_overlay_img(
                         cluster_id=plot_cluster_name,
                         features=features,
                         feature_x=self.plot_x_axis_name,
@@ -686,6 +692,8 @@ class PlotterWidget(QMainWindow):
                         histogram_data=self.graphics_widget.histogram,
                         hide_first_cluster=self.plot_hide_non_selected.isChecked(),
                     )
+                    print("SET OV")
+                    self.graphics_widget.set_selector_cluster_id_overlay(self.cluster_id_histo_overlay)
                     xedges = self.graphics_widget.histogram[1]
                     yedges = self.graphics_widget.histogram[2]
 

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -692,7 +692,6 @@ class PlotterWidget(QMainWindow):
                         histogram_data=self.graphics_widget.histogram,
                         hide_first_cluster=self.plot_hide_non_selected.isChecked(),
                     )
-                    print("SET OV")
                     self.graphics_widget.set_selector_cluster_id_overlay(self.cluster_id_histo_overlay)
                     xedges = self.graphics_widget.histogram[1]
                     yedges = self.graphics_widget.histogram[2]

--- a/napari_clusters_plotter/_plotter.py
+++ b/napari_clusters_plotter/_plotter.py
@@ -102,9 +102,11 @@ class PlotterWidget(QMainWindow):
             features = get_layer_tabular_data(self.analysed_layer)
 
             modifiers = QGuiApplication.keyboardModifiers()
-            if 'delete_cluster' in kwargs:
+            if "delete_cluster" in kwargs:
                 features[clustering_ID].mask(
-                    features[clustering_ID]==kwargs['delete_cluster'], other=-1, inplace=True
+                    features[clustering_ID] == kwargs["delete_cluster"],
+                    other=-1,
+                    inplace=True,
                 )
 
             elif modifiers == Qt.ShiftModifier and clustering_ID in features.keys():
@@ -692,7 +694,9 @@ class PlotterWidget(QMainWindow):
                         histogram_data=self.graphics_widget.histogram,
                         hide_first_cluster=self.plot_hide_non_selected.isChecked(),
                     )
-                    self.graphics_widget.set_selector_cluster_id_overlay(self.cluster_id_histo_overlay)
+                    self.graphics_widget.set_selector_cluster_id_overlay(
+                        self.cluster_id_histo_overlay
+                    )
                     xedges = self.graphics_widget.histogram[1]
                     yedges = self.graphics_widget.histogram[2]
 

--- a/napari_clusters_plotter/_plotter_utilities.py
+++ b/napari_clusters_plotter/_plotter_utilities.py
@@ -568,4 +568,6 @@ def make_cluster_overlay_img(
         cluster_overlay_rgba[mask] = rgba
         cluster_overlay_cluster_id[mask] = cluster
 
-    return cluster_overlay_rgba.swapaxes(0, 1), cluster_overlay_cluster_id.swapaxes(0, 1)
+    return cluster_overlay_rgba.swapaxes(0, 1), cluster_overlay_cluster_id.swapaxes(
+        0, 1
+    )

--- a/napari_clusters_plotter/_plotter_utilities.py
+++ b/napari_clusters_plotter/_plotter_utilities.py
@@ -549,6 +549,7 @@ def make_cluster_overlay_img(
         ]
 
     cluster_overlay_rgba = np.zeros((*h.shape, 4), dtype=float)
+    cluster_overlay_cluster_id = np.zeros((*h.shape, 1), dtype=int)
     output_max = np.zeros(h.shape, dtype=float)
 
     for cluster, entries in relevant_entries.groupby(cluster_id):
@@ -565,5 +566,6 @@ def make_cluster_overlay_img(
         ]
         rgba.append(0.9)
         cluster_overlay_rgba[mask] = rgba
+        cluster_overlay_cluster_id[mask] = cluster
 
-    return cluster_overlay_rgba.swapaxes(0, 1)
+    return cluster_overlay_rgba.swapaxes(0, 1), cluster_overlay_cluster_id.swapaxes(0, 1)


### PR DESCRIPTION
This is my attempt for an implementation to  deselected clusters (#289):

If you keep control pressed and click on a cluster, it gets deleted.

![vokoscreenNG-2023-12-18_16-11-03](https://github.com/BiAPoL/napari-clusters-plotter/assets/1113977/b79a55dd-093d-4071-93fb-ca04e58f952d)
