### PR TITLE
Update axes limits when plotting

### DIFF
--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -617,6 +617,7 @@ class MplCanvas(FigureCanvas):
         )
         self.axes.set_xlim(xedges[0], xedges[-1])
         self.axes.set_ylim(yedges[0], yedges[-1])
+        self.xylim = (self.axes.get_xlim(), self.axes.get_ylim())
         self.histogram = (h, xedges, yedges)
         self.selector.disconnect()
         self.selector = SelectFrom2DHistogram(self, self.axes, self.full_data)

--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -675,6 +675,7 @@ class MplCanvas(FigureCanvas):
             self.axes,
             self.pts,
         )
+        self.xylim = (self.axes.get_xlim(), self.axes.get_ylim())
 
     def match_napari_layout(self):
         """Change background and axes colors to match napari layout"""


### PR DESCRIPTION
I noticed that when switching between layers, the axis limits of the plots are not updated properly. This is due to reset_zoom being called with old axis limits. This PR fixes the problem. 