### PR TITLE
Fix bug where some colormaps were not displayed in the historam

### DIFF
--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -11,7 +11,9 @@ from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as Navigatio
 from matplotlib.figure import Figure
 from matplotlib.path import Path
 from matplotlib.widgets import LassoSelector, RectangleSelector, SpanSelector
+from matplotlib.colors import LinearSegmentedColormap
 from napari.layers import Image, Layer
+from napari.utils.colormaps import ALL_COLORMAPS
 from qtpy.QtCore import QRect
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import (
@@ -616,7 +618,7 @@ class MplCanvas(FigureCanvas):
             h.T,
             extent=[xedges[0], xedges[-1], yedges[0], yedges[-1]],
             origin="lower",
-            cmap=self.selected_colormap,
+            cmap=LinearSegmentedColormap.from_list(self.selected_colormap, ALL_COLORMAPS[self.selected_colormap].colors),
             aspect="auto",
             norm=norm,
         )

--- a/napari_clusters_plotter/_Qt_code.py
+++ b/napari_clusters_plotter/_Qt_code.py
@@ -8,10 +8,10 @@ import pandas as pd
 from magicgui.widgets import create_widget
 from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
+from matplotlib.colors import LinearSegmentedColormap
 from matplotlib.figure import Figure
 from matplotlib.path import Path
 from matplotlib.widgets import LassoSelector, RectangleSelector, SpanSelector
-from matplotlib.colors import LinearSegmentedColormap
 from napari.layers import Image, Layer
 from napari.utils.colormaps import ALL_COLORMAPS
 from qtpy.QtCore import QRect
@@ -618,7 +618,9 @@ class MplCanvas(FigureCanvas):
             h.T,
             extent=[xedges[0], xedges[-1], yedges[0], yedges[-1]],
             origin="lower",
-            cmap=LinearSegmentedColormap.from_list(self.selected_colormap, ALL_COLORMAPS[self.selected_colormap].colors),
+            cmap=LinearSegmentedColormap.from_list(
+                self.selected_colormap, ALL_COLORMAPS[self.selected_colormap].colors
+            ),
             aspect="auto",
             norm=norm,
         )


### PR DESCRIPTION
Colormaps from napari were not displayed on the histogram because they were not converted to matplotlib colormaps