### PR TITLE
prefer loading features from `features` rather than `properties`

### DIFF
--- a/napari_clusters_plotter/_utilities.py
+++ b/napari_clusters_plotter/_utilities.py
@@ -146,10 +146,10 @@ def get_layer_tabular_data(layer):
     pandas.DataFrame or None
         A DataFrame containing the tabular data, or None if no data was found.
     """
-    if hasattr(layer, "properties") and layer.properties is not None:
-        return pd.DataFrame(layer.properties)
     if hasattr(layer, "features") and layer.features is not None:
         return layer.features
+    if hasattr(layer, "properties") and layer.properties is not None:
+        return pd.DataFrame(layer.properties)
     return None
 
 


### PR DESCRIPTION
I had some issues that the `features` could not be read into the plotter widget once a dimensionality reduction was done. This is likely due to the fact that somewhere in the code, the `properties` attribute of the processed layer is set to `{}`. This in turn leads to unintended behavior in the `getlayer_tabular_data` function:

```python
def get_layer_tabular_data(layer):
    """
    Return tabular data associated with a layer object.

    Parameters:
    -----------
    layer : object (napari layer)
        An object that may contain tabular data as either properties (older napari versions) or features.

    Returns :
    --------
    pandas.DataFrame or None
        A DataFrame containing the tabular data, or None if no data was found.
    """
    if hasattr(layer, "properties") and layer.properties is not None:
        return pd.DataFrame(layer.properties)
    if hasattr(layer, "features") and layer.features is not None:
        return layer.features
    return None
```

`properties` would then exist as an attribute, but it's empty, since everything relevant is in the `features` attribute. Since the latter is preferably used now, the plotter should also first try to load from there instead of the `properties`.