### PR TITLE
pass color values correctly to `DirectLabelColormap`

### DIFF
--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -386,7 +386,7 @@ def _apply_layer_color(layer, colors):
             _layer,
             "colormap",
             DirectLabelColormap(
-                {label: _color[label] for label in np.unique(_layer.data)}
+                color_dict={label: _color[label] for label in np.unique(_layer.data)}
             ),
         ),
     }


### PR DESCRIPTION
There is a bug in the call to `DirectLabelColormap` - the argument is not passed by keyword, as it should be. This PR fixes that.