### PR TITLE
Escape errors on mixed layer selection

### DIFF
--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -289,6 +289,15 @@ class PlotterWidget(BaseWidget):
         # don't do anything if no layer is selected
         if self.n_selected_layers == 0:
             return
+        
+        # check if the selected layers are of the correct type
+        selected_layer_types = [type(layer) for layer in self.viewer.layers.selection]
+        if not all([layer_type in self.input_layer_types for layer_type in selected_layer_types]):
+            return
+        
+        # check if all selected layers are of the same type
+        if len(set(selected_layer_types)) > 1:
+            return
 
         self.layers = list(self.viewer.layers.selection)
         self._update_feature_selection(None)

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -289,12 +289,19 @@ class PlotterWidget(BaseWidget):
         # don't do anything if no layer is selected
         if self.n_selected_layers == 0:
             return
-        
+
         # check if the selected layers are of the correct type
-        selected_layer_types = [type(layer) for layer in self.viewer.layers.selection]
-        if not all([layer_type in self.input_layer_types for layer_type in selected_layer_types]):
+        selected_layer_types = [
+            type(layer) for layer in self.viewer.layers.selection
+        ]
+        if not all(
+            [
+                layer_type in self.input_layer_types
+                for layer_type in selected_layer_types
+            ]
+        ):
             return
-        
+
         # check if all selected layers are of the same type
         if len(set(selected_layer_types)) > 1:
             return

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+
 def test_mixed_layers(make_napari_viewer):
     from napari_clusters_plotter import PlotterWidget
 
@@ -8,15 +9,19 @@ def test_mixed_layers(make_napari_viewer):
     viewer.window.add_dock_widget(widget, area="right")
 
     random_image = np.random.random((5, 5))
-    sample_labels = np.array([[
-        [0, 0, 0, 0, 1],
-        [0, 0, 0, 1, 1],
-        [0, 0, 1, 1, 1],
-        [0, 1, 1, 1, 1],
-        [1, 1, 1, 1, 1],
-    ]])
+    sample_labels = np.array(
+        [
+            [
+                [0, 0, 0, 0, 1],
+                [0, 0, 0, 1, 1],
+                [0, 0, 1, 1, 1],
+                [0, 1, 1, 1, 1],
+                [1, 1, 1, 1, 1],
+            ]
+        ]
+    )
 
     viewer.add_image(random_image)
     viewer.add_labels(sample_labels)
 
-    # 
+    #

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -1,0 +1,22 @@
+import numpy as np
+
+def test_mixed_layers(make_napari_viewer):
+    from napari_clusters_plotter import PlotterWidget
+
+    viewer = make_napari_viewer()
+    widget = PlotterWidget(viewer)
+    viewer.window.add_dock_widget(widget, area="right")
+
+    random_image = np.random.random((5, 5))
+    sample_labels = np.array([[
+        [0, 0, 0, 0, 1],
+        [0, 0, 0, 1, 1],
+        [0, 0, 1, 1, 1],
+        [0, 1, 1, 1, 1],
+        [1, 1, 1, 1, 1],
+    ]])
+
+    viewer.add_image(random_image)
+    viewer.add_labels(sample_labels)
+
+    # 


### PR DESCRIPTION
This makes sure that the clusters plotter widget doesn't crash if layers of different kinds are selected (which should obviously lead to some sort of pre-defined escape behavior). The way it's implemented, the plotter will just stay the same on mixed layer selecttion until the next valid selection is passed.