### PR TITLE
Fix feature sorting in combo-boxes

### DIFF
--- a/src/napari_clusters_plotter/_algorithm_widget.py
+++ b/src/napari_clusters_plotter/_algorithm_widget.py
@@ -135,7 +135,7 @@ class AlgorithmWidgetBase(BaseWidget):
             ]
         )
         self.feature_selection_widget.clear()
-        self.feature_selection_widget.addItems(features_to_add.columns)
+        self.feature_selection_widget.addItems(sorted(features_to_add.columns))
         self._update_features()
 
     @property

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -327,7 +327,7 @@ class PlotterWidget(BaseWidget):
             self._selectors[dim].clear()
 
         for dim in ["x", "y", "hue"]:
-            self._selectors[dim].addItems(self.common_columns)
+            self._selectors[dim].addItems(sorted(self.common_columns))
 
         # it should always be possible to select no color
         self._selectors["hue"].addItem("None")


### PR DESCRIPTION
Fixes #358 

Sort features alphabetically in the features combo-box.

* In `src/napari_clusters_plotter/_algorithm_widget.py`, sort features alphabetically before adding them to `feature_selection_widget` in `_on_update_layer_selection` method.
* In `src/napari_clusters_plotter/_new_plotter_widget.py`, sort features alphabetically before adding them to the combo-boxes for x, y, and hue axes in `_update_feature_selection` method.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/BiAPoL/napari-clusters-plotter/pull/359?shareId=f0cfae3d-a58a-4eec-ad8f-f0c4857d5c91).