### PR TITLE
Fix NaN handling in algorithms

### DIFF
--- a/src/napari_clusters_plotter/_algorithms.py
+++ b/src/napari_clusters_plotter/_algorithms.py
@@ -16,14 +16,23 @@ def reduce_pca(
         from sklearn.decomposition import PCA
         from sklearn.preprocessing import StandardScaler
 
+        # Remove NaN rows
+        non_nan_data = data.dropna()
+
         if scale:
-            data = StandardScaler().fit_transform(data.values)
+            non_nan_data = StandardScaler().fit_transform(non_nan_data.values)
         else:
-            data = data.values
+            non_nan_data = non_nan_data.values
 
         pca = PCA(n_components=n_components)
-        pca.fit(data)
-        return pca.transform(data)
+        pca.fit(non_nan_data)
+        reduced_data = pca.transform(non_nan_data)
+
+        # Add NaN rows back
+        result = pd.DataFrame(index=data.index, columns=range(n_components))
+        result.loc[non_nan_data.index] = reduced_data
+
+        return result
 
     return _reduce_pca(data, n_components, scale)
 
@@ -45,11 +54,19 @@ def reduce_tsne(
         from sklearn.manifold import TSNE
         from sklearn.preprocessing import StandardScaler
 
-        print("working on tsne")
+        # Remove NaN rows
+        non_nan_data = data.dropna()
+
         if scale:
-            data = StandardScaler().fit_transform(data)
+            non_nan_data = StandardScaler().fit_transform(non_nan_data)
         tsne = TSNE(n_components=n_components, perplexity=perplexity)
-        return tsne.fit_transform(data)
+        reduced_data = tsne.fit_transform(non_nan_data)
+
+        # Add NaN rows back
+        result = pd.DataFrame(index=data.index, columns=range(n_components))
+        result.loc[non_nan_data.index] = reduced_data
+
+        return result
 
     return _reduce_tsne(data, n_components, perplexity, scale)
 
@@ -71,11 +88,20 @@ def reduce_umap(
         import umap
         from sklearn.preprocessing import StandardScaler
 
+        # Remove NaN rows
+        non_nan_data = data.dropna()
+
         if scale:
-            data = StandardScaler().fit_transform(data)
+            non_nan_data = StandardScaler().fit_transform(non_nan_data)
 
         reducer = umap.UMAP(n_components=n_components, n_neighbors=n_neighbors)
-        return reducer.fit_transform(data)
+        reduced_data = reducer.fit_transform(non_nan_data)
+
+        # Add NaN rows back
+        result = pd.DataFrame(index=data.index, columns=range(n_components))
+        result.loc[non_nan_data.index] = reduced_data
+
+        return result
 
     return _reduce_umap(data, n_components, n_neighbors, scale)
 
@@ -94,11 +120,20 @@ def cluster_kmeans(
         from sklearn.cluster import KMeans
         from sklearn.preprocessing import StandardScaler
 
+        # Remove NaN rows
+        non_nan_data = data.dropna()
+
         if scale:
-            data = StandardScaler().fit_transform(data)
+            non_nan_data = StandardScaler().fit_transform(non_nan_data)
 
         kmeans = KMeans(n_clusters=n_clusters)
-        return kmeans.fit_predict(data)
+        clusters = kmeans.fit_predict(non_nan_data)
+
+        # Add NaN rows back
+        result = pd.Series(index=data.index, dtype=int)
+        result.loc[non_nan_data.index] = clusters
+
+        return result
 
     return _cluster_kmeans(data, n_clusters, scale)
 
@@ -123,13 +158,22 @@ def cluster_hdbscan(
         from sklearn.cluster import HDBSCAN
         from sklearn.preprocessing import StandardScaler
 
+        # Remove NaN rows
+        non_nan_data = data.dropna()
+
         if scale:
-            data = StandardScaler().fit_transform(data)
+            non_nan_data = StandardScaler().fit_transform(non_nan_data)
 
         clusterer = HDBSCAN(
             min_cluster_size=min_cluster_size, min_samples=min_samples
         )
-        return clusterer.fit_predict(data)
+        clusters = clusterer.fit_predict(non_nan_data)
+
+        # Add NaN rows back
+        result = pd.Series(index=data.index, dtype=int)
+        result.loc[non_nan_data.index] = clusters
+
+        return result
 
     return _cluster_hdbscan(data, min_cluster_size, min_samples, scale)
 
@@ -148,11 +192,20 @@ def cluster_gaussian_mixture(
         from sklearn.mixture import GaussianMixture
         from sklearn.preprocessing import StandardScaler
 
+        # Remove NaN rows
+        non_nan_data = data.dropna()
+
         if scale:
-            data = StandardScaler().fit_transform(data)
+            non_nan_data = StandardScaler().fit_transform(non_nan_data)
 
         gmm = GaussianMixture(n_components=n_components)
-        return gmm.fit_predict(data)
+        clusters = gmm.fit_predict(non_nan_data)
+
+        # Add NaN rows back
+        result = pd.Series(index=data.index, dtype=int)
+        result.loc[non_nan_data.index] = clusters
+
+        return result
 
     return _cluster_gaussian_mixture(data, n_components, scale)
 
@@ -171,10 +224,19 @@ def cluster_spectral(
         from sklearn.cluster import SpectralClustering
         from sklearn.preprocessing import StandardScaler
 
+        # Remove NaN rows
+        non_nan_data = data.dropna()
+
         if scale:
-            data = StandardScaler().fit_transform(data)
+            non_nan_data = StandardScaler().fit_transform(non_nan_data)
 
         clusterer = SpectralClustering(n_clusters=n_clusters)
-        return clusterer.fit_predict(data)
+        clusters = clusterer.fit_predict(non_nan_data)
+
+        # Add NaN rows back
+        result = pd.Series(index=data.index, dtype=int)
+        result.loc[non_nan_data.index] = clusters
+
+        return result
 
     return _cluster_spectral(data, n_clusters, scale)


### PR DESCRIPTION
Modify algorithm functions to handle NaN values by removing NaN rows before processing and adding them back after processing.

* Modify `reduce_pca` to remove NaN rows before processing and add them back after processing.
* Modify `reduce_tsne` to remove NaN rows before processing and add them back after processing.
* Modify `reduce_umap` to remove NaN rows before processing and add them back after processing.
* Modify `cluster_kmeans` to remove NaN rows before processing and add them back after processing.
* Modify `cluster_hdbscan` to remove NaN rows before processing and add them back after processing.
* Modify `cluster_gaussian_mixture` to remove NaN rows before processing and add them back after processing.
* Modify `cluster_spectral` to remove NaN rows before processing and add them back after processing.

