### PR TITLE
add LAYER_SELECTED_DATA_CLUSTER_ID to cluster from layer space

### DIFF
--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -312,15 +312,12 @@ class PlotterWidget(BaseWidget):
             if type(layer) is napari.layers.Points:
                 layer.selected_data.events.items_changed.connect(
                     lambda selected_data: self._update_layer_selected_data_feature(
-                        layer,
-                        selected_data
+                        layer, selected_data
                     )
                 )
 
     def _update_layer_selected_data_feature(
-            self,
-            layer: napari.layers.Points,
-            selected_data: np.ndarray
+        self, layer: napari.layers.Points, selected_data: np.ndarray
     ) -> None:
         """
         Update the layer selected_data to feature.

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -308,6 +308,27 @@ class PlotterWidget(BaseWidget):
         for layer in self.layers:
             layer.events.features.connect(self._update_feature_selection)
 
+            # if layer is a Point Layer
+            if type(layer) is napari.layers.Points:
+                layer.selected_data.events.items_changed.connect(
+                    lambda selected_data: self._update_layer_selected_data_feature(
+                        layer,
+                        selected_data
+                    )
+                )
+
+    def _update_layer_selected_data_feature(
+            self,
+            layer: napari.layers.Points,
+            selected_data: np.ndarray
+    ) -> None:
+        """
+        Update the layer selected_data to feature.
+        """
+        cluster = np.zeros(layer.data.shape[0])
+        cluster[list(selected_data)] = 1
+        layer.features["LAYER_SELECTED_DATA_CLUSTER_ID"] = cluster
+
     def _update_feature_selection(
         self, event: napari.utils.events.Event
     ) -> None:

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -131,6 +131,4 @@ def test_layer_selection(make_napari_viewer, n_samples: int = 100):
     # make sure that the cluster selection is the same
     cluster = np.zeros(layer2.data.shape[0])
     cluster[list(selection)] = 1
-    assert np.all(
-        layer2.features["LAYER_SELECTED_DATA_CLUSTER_ID"] == cluster
-    )
+    assert np.all(layer2.features["LAYER_SELECTED_DATA_CLUSTER_ID"] == cluster)

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -108,3 +108,29 @@ def test_cluster_memorization(make_napari_viewer, n_samples: int = 100):
         plotter_widget.plotting_widget.active_artist.color_indices
         == cluster_indeces
     )
+
+
+def test_layer_selection(make_napari_viewer, n_samples: int = 100):
+    from napari_clusters_plotter import PlotterWidget
+
+    viewer = make_napari_viewer()
+    _, layer2 = create_multi_point_layer(n_samples=n_samples)
+
+    # add layers to viewer
+    viewer.add_layer(layer2)
+    plotter_widget = PlotterWidget(viewer)
+    viewer.window.add_dock_widget(plotter_widget, area="right")
+
+    # select last layer and create a random selection on the layer
+    viewer.layers.selection.active = layer2
+    selection = np.random.randint(0, 1, len(layer2.data))
+    layer2.selected_data = selection
+
+    assert "LAYER_SELECTED_DATA_CLUSTER_ID" in layer2.features.columns
+
+    # make sure that the cluster selection is the same
+    cluster = np.zeros(layer2.data.shape[0])
+    cluster[list(selection)] = 1
+    assert np.all(
+        layer2.features["LAYER_SELECTED_DATA_CLUSTER_ID"] == cluster
+    )


### PR DESCRIPTION
Hello,

Attempt to close #363 

In this PR I propose to add to `v.0.9.0` the point layer features column `LAYER_SELECTED_DATA_CLUSTER_ID`.

The event connection is added during `_on_update_layer_selection` (and never removed?). This allow the user to select points in the layer to appear on the plotter canvas through features.

---

`v0.9.0` seems amazing! For example, the ability to select several layers and to plot them on the same plotter canvas is something I didn't know I needed.

I feel I didn't understand how to change the `color_indices` by using another `CLUSTER_ID` than `MANUAL_CLUSTER_ID` but maybe it is not implemented yet?

I tried to keep the PR minimal because I am unsure about how v0.9.0 will be developed, but I can of course change the implementation / names.

Thank you for your time 