### PR TITLE
Move layer check into base widget

### DIFF
--- a/src/napari_clusters_plotter/_algorithm_widget.py
+++ b/src/napari_clusters_plotter/_algorithm_widget.py
@@ -9,8 +9,25 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
+from napari.layers import (
+    Labels,
+    Points,
+    Surface,
+    Vectors,
+    Shapes,
+)
+
 
 class BaseWidget(QWidget):
+
+    input_layer_types = [
+        Labels,
+        Points,
+        Surface,
+        Vectors,
+        Shapes,
+    ]
+    
     def __init__(self, napari_viewer):
         super().__init__()
 
@@ -34,6 +51,13 @@ class BaseWidget(QWidget):
         ]
         common_columns = list(set.intersection(*map(set, common_columns)))
         return common_columns
+    
+    @property
+    def n_selected_layers(self) -> int:
+        """
+        Number of currently selected layers.
+        """
+        return len(list(self.viewer.layers.selection))
 
 
 class AlgorithmWidgetBase(BaseWidget):
@@ -123,6 +147,19 @@ class AlgorithmWidgetBase(BaseWidget):
 
     def _on_update_layer_selection(self, layer):
         self.layers = list(self.viewer.layers.selection)
+
+        # don't do anything if no layer is selected
+        if self.n_selected_layers == 0:
+            return
+
+        # check if the selected layers are of the correct type
+        selected_layer_types = [
+            type(layer) for layer in self.viewer.layers.selection
+        ]
+        for layer_type in selected_layer_types:
+            if layer_type not in self.input_layer_types:
+                return
+
         features_to_add = self._get_features()[self.common_columns]
         column_strings = [
             algo["column_string"] for algo in self.algorithms.values()

--- a/src/napari_clusters_plotter/_algorithm_widget.py
+++ b/src/napari_clusters_plotter/_algorithm_widget.py
@@ -1,5 +1,12 @@
 import pandas as pd
 from magicgui import magicgui
+from napari.layers import (
+    Labels,
+    Points,
+    Shapes,
+    Surface,
+    Vectors,
+)
 from qtpy.QtWidgets import (
     QAbstractItemView,
     QComboBox,
@@ -7,14 +14,6 @@ from qtpy.QtWidgets import (
     QListWidget,
     QVBoxLayout,
     QWidget,
-)
-
-from napari.layers import (
-    Labels,
-    Points,
-    Surface,
-    Vectors,
-    Shapes,
 )
 
 
@@ -27,7 +26,7 @@ class BaseWidget(QWidget):
         Vectors,
         Shapes,
     ]
-    
+
     def __init__(self, napari_viewer):
         super().__init__()
 
@@ -51,7 +50,7 @@ class BaseWidget(QWidget):
         ]
         common_columns = list(set.intersection(*map(set, common_columns)))
         return common_columns
-    
+
     @property
     def n_selected_layers(self) -> int:
         """

--- a/src/napari_clusters_plotter/_dim_reduction_and_clustering.py
+++ b/src/napari_clusters_plotter/_dim_reduction_and_clustering.py
@@ -88,9 +88,7 @@ class DimensionalityReductionWidget(AlgorithmWidgetBase):
         for layer in self.layers:
             current_features = layer.features
             for column in column_names:
-                layer_feature_subset = result[
-                    result["layer"] == layer.name
-                ]
+                layer_feature_subset = result[result["layer"] == layer.name]
 
                 # add the columns to the features
                 current_features[column] = layer_feature_subset[column].values

--- a/src/napari_clusters_plotter/_dim_reduction_and_clustering.py
+++ b/src/napari_clusters_plotter/_dim_reduction_and_clustering.py
@@ -74,7 +74,7 @@ class DimensionalityReductionWidget(AlgorithmWidgetBase):
             ["PCA", "t-SNE", "UMAP"],
         )
 
-    def _process_result(self, result):
+    def _process_result(self, result: pd.DataFrame):
         """
         Process result of dimensionality reduction algorithm and update layer
         """
@@ -82,14 +82,14 @@ class DimensionalityReductionWidget(AlgorithmWidgetBase):
             f"{self.algorithms[self.selected_algorithm]['column_string']}{i}"
             for i in range(result.shape[1])
         ]
-        features_reduced = pd.DataFrame(result, columns=column_names)
-        features_reduced["layer"] = self._get_features()["layer"].values
+        result.columns = column_names
+        result["layer"] = self._get_features()["layer"].values
 
         for layer in self.layers:
             current_features = layer.features
             for column in column_names:
-                layer_feature_subset = features_reduced[
-                    features_reduced["layer"] == layer.name
+                layer_feature_subset = result[
+                    result["layer"] == layer.name
                 ]
 
                 # add the columns to the features

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -27,14 +27,6 @@ class PlotterWidget(BaseWidget):
         The napari viewer to connect to.
     """
 
-    input_layer_types = [
-        napari.layers.Labels,
-        napari.layers.Points,
-        napari.layers.Surface,
-        napari.layers.Vectors,
-        napari.layers.Shapes,
-    ]
-
     plot_needs_update = Signal()
 
     def __init__(self, napari_viewer):
@@ -272,13 +264,6 @@ class PlotterWidget(BaseWidget):
         self.control_widget.hue_box.setCurrentText(
             column
         )  # TODO insert checks and change values
-
-    @property
-    def n_selected_layers(self) -> int:
-        """
-        Number of currently selected layers.
-        """
-        return len(list(self.viewer.layers.selection))
 
     def _on_update_layer_selection(
         self, event: napari.utils.events.Event


### PR DESCRIPTION
This pull request includes several changes to enhance the functionality and maintainability of the `napari_clusters_plotter` package. The most important changes include adding input layer types to the `BaseWidget` class, implementing a property to count selected layers, and updating the layer selection logic to ensure only valid layers are processed.

Enhancements to layer handling:

* [`src/napari_clusters_plotter/_algorithm_widget.py`](diffhunk://#diff-a47db6b3042af68f2254073d1a78dfd5ee32b1913eb50534391995aedadf2430R12-R30): Added input layer types (`Labels`, `Points`, `Surface`, `Vectors`, `Shapes`) to the `BaseWidget` class.
* [`src/napari_clusters_plotter/_algorithm_widget.py`](diffhunk://#diff-a47db6b3042af68f2254073d1a78dfd5ee32b1913eb50534391995aedadf2430R55-R61): Implemented `n_selected_layers` property to count the number of selected layers.
* [`src/napari_clusters_plotter/_algorithm_widget.py`](diffhunk://#diff-a47db6b3042af68f2254073d1a78dfd5ee32b1913eb50534391995aedadf2430R150-R162): Updated `_on_update_layer_selection` method to check if selected layers are of the correct type and to handle cases where no layers are selected.

Code simplification and refactoring:

* [`src/napari_clusters_plotter/_dim_reduction_and_clustering.py`](diffhunk://#diff-83cea866110aed63aaeabf03765385b2ac32b83774e8cc6a7da9244f7f75da2eL77-R92): Refactored `_process_result` method to directly update the result DataFrame columns and layer features.
* [`src/napari_clusters_plotter/_new_plotter_widget.py`](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01L30-L37): Removed redundant input layer types and `n_selected_layers` property from `PlotterWidget` class. [[1]](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01L30-L37) [[2]](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01L276-L282)