### PR TITLE
Color hue combobox background if column is categorical

### DIFF
--- a/src/napari_clusters_plotter/_algorithm_widget.py
+++ b/src/napari_clusters_plotter/_algorithm_widget.py
@@ -50,7 +50,7 @@ class BaseWidget(QWidget):
         ]
         common_columns = list(set.intersection(*map(set, common_columns)))
         return common_columns
-    
+
     @property
     def category_columns(self):
         """Return the column names that are of type 'category'."""

--- a/src/napari_clusters_plotter/_algorithm_widget.py
+++ b/src/napari_clusters_plotter/_algorithm_widget.py
@@ -50,6 +50,18 @@ class BaseWidget(QWidget):
         ]
         common_columns = list(set.intersection(*map(set, common_columns)))
         return common_columns
+    
+    @property
+    def category_columns(self):
+        """Return the column names that are of type 'category'."""
+        if len(self.layers) == 0:
+            return []
+        category_columns = [
+            list(layer.features.select_dtypes(include=["category"]).columns)
+            for layer in self.layers
+        ]
+        category_columns = list(set.intersection(*map(set, category_columns)))
+        return category_columns
 
     @property
     def n_selected_layers(self) -> int:

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -8,7 +8,7 @@ from napari.utils.colormaps import ALL_COLORMAPS
 from qtpy import uic
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QComboBox, QVBoxLayout, QWidget
-from PyQt5.QtGui import QColor
+from qtpy.QtGui import QColor
 
 from ._algorithm_widget import BaseWidget
 

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -311,19 +311,28 @@ class PlotterWidget(BaseWidget):
         for dim in ["x", "y", "hue"]:
             self._selectors[dim].clear()
 
-
-        special_items = ["label"]
         for dim in ["x", "y", "hue"]:
             features_to_add = sorted(self.common_columns)
+            category_columns = self.category_columns
+            # Remove category_columns from features to add if dim is x or y
+            if dim in ["x", "y"]:
+                features_to_add = [
+                    feature for feature in features_to_add if feature not in category_columns
+                ]
+            # TODO: remove this once "MANUAL_CLUSTER_ID" becomes categorical
             if "MANUAL_CLUSTER_ID" in features_to_add:
                 features_to_add.remove("MANUAL_CLUSTER_ID")
 
             self._selectors[dim].addItems(features_to_add)
             for feature in features_to_add:
-                if feature in special_items:
+                if feature in category_columns:
                     index = self._selectors[dim].findText(feature)
                     self._selectors[dim].setItemData(
-                        index, QColor("red"), Qt.BackgroundRole
+                        index, QColor("darkCyan"), Qt.BackgroundRole
+                    )
+                    # Set tooltip
+                    self._selectors[dim].setItemData(
+                        index, "Categorical Column", Qt.ToolTipRole
                     )
                     
 

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -8,6 +8,7 @@ from napari.utils.colormaps import ALL_COLORMAPS
 from qtpy import uic
 from qtpy.QtCore import Qt, Signal
 from qtpy.QtWidgets import QComboBox, QVBoxLayout, QWidget
+from PyQt5.QtGui import QColor
 
 from ._algorithm_widget import BaseWidget
 
@@ -15,7 +16,6 @@ from ._algorithm_widget import BaseWidget
 class PlottingType(Enum):
     HISTOGRAM = auto()
     SCATTER = auto()
-
 
 class PlotterWidget(BaseWidget):
     """
@@ -311,12 +311,21 @@ class PlotterWidget(BaseWidget):
         for dim in ["x", "y", "hue"]:
             self._selectors[dim].clear()
 
+
+        special_items = ["label"]
         for dim in ["x", "y", "hue"]:
             features_to_add = sorted(self.common_columns)
             if "MANUAL_CLUSTER_ID" in features_to_add:
                 features_to_add.remove("MANUAL_CLUSTER_ID")
 
             self._selectors[dim].addItems(features_to_add)
+            for feature in features_to_add:
+                if feature in special_items:
+                    index = self._selectors[dim].findText(feature)
+                    self._selectors[dim].setItemData(
+                        index, QColor("red"), Qt.BackgroundRole
+                    )
+                    
 
         # it should always be possible to select no color
         self._selectors["hue"].addItem("None")

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -7,8 +7,8 @@ from biaplotter.plotter import ArtistType, CanvasWidget
 from napari.utils.colormaps import ALL_COLORMAPS
 from qtpy import uic
 from qtpy.QtCore import Qt, Signal
-from qtpy.QtWidgets import QComboBox, QVBoxLayout, QWidget
 from qtpy.QtGui import QColor
+from qtpy.QtWidgets import QComboBox, QVBoxLayout, QWidget
 
 from ._algorithm_widget import BaseWidget
 
@@ -16,6 +16,7 @@ from ._algorithm_widget import BaseWidget
 class PlottingType(Enum):
     HISTOGRAM = auto()
     SCATTER = auto()
+
 
 class PlotterWidget(BaseWidget):
     """
@@ -317,7 +318,9 @@ class PlotterWidget(BaseWidget):
             # Remove category_columns from features to add if dim is x or y
             if dim in ["x", "y"]:
                 features_to_add = [
-                    feature for feature in features_to_add if feature not in category_columns
+                    feature
+                    for feature in features_to_add
+                    if feature not in category_columns
                 ]
             # TODO: remove this once "MANUAL_CLUSTER_ID" becomes categorical
             if "MANUAL_CLUSTER_ID" in features_to_add:
@@ -334,7 +337,6 @@ class PlotterWidget(BaseWidget):
                     self._selectors[dim].setItemData(
                         index, "Categorical Column", Qt.ToolTipRole
                     )
-                    
 
         # it should always be possible to select no color
         self._selectors["hue"].addItem("None")


### PR DESCRIPTION
This adds a dark cyan background color to features that are categorical in the "hue" combobox.

Once [this PR](https://github.com/BiAPoL/biaplotter/pull/18) in biaplotter is merged, one should be able to color the histogram/scatter by a regular feature (using a continuous colormap) or with the default categorical colors.

The changes in this PR will only work after:
- merging the pPR 18](https://github.com/BiAPoL/biaplotter/pull/18) in biaplotter;
- enabling the "hue" combobox;
- setting certain columns in the dataframe to ["category" dtype](https://pandas.pydata.org/docs/user_guide/categorical.html)