### PR TITLE
expand tests

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-latest] # macos-latest (disabled, see related issue)
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,14 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = python{39}-{linux,macos,windows}
+envlist = python{39, 310, 311, 312, 313}-{linux,macos,windows}
 
 [gh-actions]
 python =
     3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312
+    3.13: py313
 
 [gh-actions:env]
 PLATFORM =


### PR DESCRIPTION
Fixes #373 

This pull request includes an update to the CI configuration file to expand the range of Python versions tested.

* [`.github/workflows/test_and_deploy.yml`](diffhunk://#diff-26f81082456d6a7a3832ccb6bcacb1560e1db2f552e3d57a4da90097aacba804L28-R28): Added Python versions 3.12 and 3.13 to the matrix for testing.