### PR TITLE
add test for multiscale data

### DIFF
--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -7,29 +7,28 @@ def create_multiscale_labels():
     """
     from napari.layers import Labels
 
-    labels = np.array([
-        [1, 1, 1, 4, 4, 4],
-        [1, 1, 1, 4, 4, 4],
-        [1, 1, 1, 0, 0, 0],
-        [0, 0, 0, 2, 2, 2],
-        [3, 3, 0, 2, 2, 2],
-        [3, 3, 0, 2, 2, 2],
-    ])
+    labels = np.array(
+        [
+            [1, 1, 1, 4, 4, 4],
+            [1, 1, 1, 4, 4, 4],
+            [1, 1, 1, 0, 0, 0],
+            [0, 0, 0, 2, 2, 2],
+            [3, 3, 0, 2, 2, 2],
+            [3, 3, 0, 2, 2, 2],
+        ]
+    )
 
-    multi_scale_labels = [
-        labels,
-        labels[::2, ::2]
-    ]
+    multi_scale_labels = [labels, labels[::2, ::2]]
 
     layer = Labels(
         multi_scale_labels,
         name="multiscale_labels",
     )
 
-    layer.features['feature1'] = np.random.normal(4)
-    layer.features['feature2'] = np.random.normal(4)
-    layer.features['feature3'] = np.random.normal(4)
-    layer.features['feature4'] = np.random.normal(4)
+    layer.features["feature1"] = np.random.normal(4)
+    layer.features["feature2"] = np.random.normal(4)
+    layer.features["feature3"] = np.random.normal(4)
+    layer.features["feature4"] = np.random.normal(4)
 
     return layer
 

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -310,7 +310,6 @@ def test_multiscale_plotter(make_napari_viewer):
     plotter_widget._selectors["y"].setCurrentText("feature2")
 
 
-
 @pytest.mark.parametrize(
     "create_sample_layers",
     [

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -1,6 +1,39 @@
 import numpy as np
 
 
+def create_multiscale_labels():
+    """
+    Create a multiscale labels layer with two scales.
+    """
+    from napari.layers import Labels
+
+    labels = np.array([
+        [1, 1, 1, 4, 4, 4],
+        [1, 1, 1, 4, 4, 4],
+        [1, 1, 1, 0, 0, 0],
+        [0, 0, 0, 2, 2, 2],
+        [3, 3, 0, 2, 2, 2],
+        [3, 3, 0, 2, 2, 2],
+    ])
+
+    multi_scale_labels = [
+        labels,
+        labels[::2, ::2]
+    ]
+
+    layer = Labels(
+        multi_scale_labels,
+        name="multiscale_labels",
+    )
+
+    layer.features['feature1'] = np.random.normal(4)
+    layer.features['feature2'] = np.random.normal(4)
+    layer.features['feature3'] = np.random.normal(4)
+    layer.features['feature4'] = np.random.normal(4)
+
+    return layer
+
+
 def create_multi_point_layer(n_samples: int = 100):
     import pandas as pd
     from napari.layers import Points
@@ -108,3 +141,18 @@ def test_cluster_memorization(make_napari_viewer, n_samples: int = 100):
         plotter_widget.plotting_widget.active_artist.color_indices
         == cluster_indeces
     )
+
+
+def test_multiscale_plotter(make_napari_viewer):
+    from napari_clusters_plotter import PlotterWidget
+
+    viewer = make_napari_viewer()
+    plotter_widget = PlotterWidget(viewer)
+    viewer.window.add_dock_widget(plotter_widget, area="right")
+
+    layer = create_multiscale_labels()
+    viewer.add_layer(layer)
+
+    # select some random features in the plotting widget
+    plotter_widget._selectors["x"].setCurrentText("feature1")
+    plotter_widget._selectors["y"].setCurrentText("feature2")


### PR DESCRIPTION
Relevant for #212 

This pull request introduces a new function to create a multiscale labels layer and adds a corresponding test to verify the functionality. The most important changes include the addition of the `create_multiscale_labels` function and the `test_multiscale_plotter` test case.

New functionality:

* [`src/napari_clusters_plotter/_tests/test_plotter.py`](diffhunk://#diff-2d655e0941ae671331bd4bc1e0682a27920b236d70a1623496683969eaa87c04R4-R36): Added `create_multiscale_labels` function to create a multiscale labels layer with two scales.

New test case:

* [`src/napari_clusters_plotter/_tests/test_plotter.py`](diffhunk://#diff-2d655e0941ae671331bd4bc1e0682a27920b236d70a1623496683969eaa87c04R144-R158): Added `test_multiscale_plotter` function to test the multiscale labels layer with the `PlotterWidget`.