### PR TITLE
remove debug code in demo notebook

### DIFF
--- a/notebooks/demo_new_plotter.ipynb
+++ b/notebooks/demo_new_plotter.ipynb
@@ -18,7 +18,15 @@
    "cell_type": "code",
    "execution_count": 2,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "WARNING: QWindowsWindow::setGeometry: Unable to set geometry 3440x1377+640+280 (frame: 3456x1416+632+249) on QWidgetWindow/\"_QtMainWindowClassWindow\" on \"\\\\.\\DISPLAY1\". Resulting geometry: 1924x1061+640+280 (frame: 1940x1100+632+249) margins: 8, 31, 8, 8 minimum size: 385x501 MINMAXINFO(maxSize=POINT(x=0, y=0), maxpos=POINT(x=0, y=0), maxtrack=POINT(x=0, y=0), mintrack=POINT(x=401, y=540)))\n"
+     ]
+    }
+   ],
    "source": [
     "viewer = napari.Viewer()"
    ]
@@ -38,7 +46,7 @@
     {
      "data": {
       "text/plain": [
-       "<Points layer 'points2' at 0x12998840130>"
+       "<Points layer 'points2' at 0x2655e1294f0>"
       ]
      },
      "execution_count": 3,
@@ -89,16 +97,14 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "c:\\Users\\johan\\mambaforge\\envs\\clusters-plotter\\lib\\site-packages\\napari_matplotlib\\base.py:46: FutureWarning: The `as_dict` kwarg has been deprecated since Napari 0.5.0 and will be removed in future version. You can use `get_theme(...).to_rgb_dict()`\n",
-      "  get_theme(napari_viewer.theme, as_dict=False)\n",
-      "c:\\Users\\johan\\mambaforge\\envs\\clusters-plotter\\lib\\site-packages\\napari_matplotlib\\base.py:101: FutureWarning: The `as_dict` kwarg has been deprecated since Napari 0.5.0 and will be removed in future version. You can use `get_theme(...).to_rgb_dict()`\n",
-      "  theme = napari.utils.theme.get_theme(self.viewer.theme, as_dict=False)\n"
+      "c:\\Users\\johamuel\\AppData\\Local\\miniforge3\\envs\\clusters-plotter\\Lib\\site-packages\\biaplotter\\colormap.py:34: UserWarning: Categorical colormap detected. Setting categorical=True. If the colormap is continuous, set categorical=False explicitly.\n",
+      "  warnings.warn(\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "<napari._qt.widgets.qt_viewer_dock_widget.QtViewerDockWidget at 0x1299a10a820>"
+       "<napari._qt.widgets.qt_viewer_dock_widget.QtViewerDockWidget at 0x2656185ccd0>"
       ]
      },
      "execution_count": 4,
@@ -109,379 +115,6 @@
    "source": [
     "plotter_widget = PlotterWidget(viewer)\n",
     "viewer.window.add_dock_widget(plotter_widget, area='right')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>frame</th>\n",
-       "      <th>feature2</th>\n",
-       "      <th>feature3</th>\n",
-       "      <th>feature4</th>\n",
-       "      <th>MANUAL_CLUSTER_ID</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>0</td>\n",
-       "      <td>-4.725088</td>\n",
-       "      <td>-4.325642</td>\n",
-       "      <td>-7.112442</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>0</td>\n",
-       "      <td>-4.386041</td>\n",
-       "      <td>-5.335577</td>\n",
-       "      <td>-6.063437</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>0</td>\n",
-       "      <td>-5.730792</td>\n",
-       "      <td>-4.642161</td>\n",
-       "      <td>-4.429953</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>0</td>\n",
-       "      <td>-6.089492</td>\n",
-       "      <td>-2.991715</td>\n",
-       "      <td>-5.544447</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>0</td>\n",
-       "      <td>-4.740159</td>\n",
-       "      <td>-5.189429</td>\n",
-       "      <td>-4.769790</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>94</th>\n",
-       "      <td>4</td>\n",
-       "      <td>-5.815555</td>\n",
-       "      <td>-4.737373</td>\n",
-       "      <td>-4.945831</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>95</th>\n",
-       "      <td>4</td>\n",
-       "      <td>-6.226173</td>\n",
-       "      <td>-3.972162</td>\n",
-       "      <td>-6.477352</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>96</th>\n",
-       "      <td>4</td>\n",
-       "      <td>-4.597238</td>\n",
-       "      <td>-3.308072</td>\n",
-       "      <td>-4.418548</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>97</th>\n",
-       "      <td>4</td>\n",
-       "      <td>-6.143753</td>\n",
-       "      <td>-5.130647</td>\n",
-       "      <td>-5.700410</td>\n",
-       "      <td>0</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>98</th>\n",
-       "      <td>4</td>\n",
-       "      <td>-4.029651</td>\n",
-       "      <td>-5.172430</td>\n",
-       "      <td>-5.987246</td>\n",
-       "      <td>1</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>99 rows × 5 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "    frame  feature2  feature3  feature4  MANUAL_CLUSTER_ID\n",
-       "0       0 -4.725088 -4.325642 -7.112442                  1\n",
-       "1       0 -4.386041 -5.335577 -6.063437                  1\n",
-       "2       0 -5.730792 -4.642161 -4.429953                  1\n",
-       "3       0 -6.089492 -2.991715 -5.544447                  0\n",
-       "4       0 -4.740159 -5.189429 -4.769790                  1\n",
-       "..    ...       ...       ...       ...                ...\n",
-       "94      4 -5.815555 -4.737373 -4.945831                  0\n",
-       "95      4 -6.226173 -3.972162 -6.477352                  0\n",
-       "96      4 -4.597238 -3.308072 -4.418548                  0\n",
-       "97      4 -6.143753 -5.130647 -5.700410                  0\n",
-       "98      4 -4.029651 -5.172430 -5.987246                  1\n",
-       "\n",
-       "[99 rows x 5 columns]"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "viewer.layers[-1].features"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "(99, 4)"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "viewer.layers[1].data.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([1, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0,\n",
-       "       0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0,\n",
-       "       0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 1, 1, 0, 1, 0, 0,\n",
-       "       1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 0, 1,\n",
-       "       0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0])"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "viewer.layers.selection.active = viewer.layers[-1]\n",
-    "plotter_widget._selectors['x'].setCurrentText('feature3')\n",
-    "plotter_widget.plotting_widget.active_artist.color_indices = np.random.randint(0, 2, n_samples)\n",
-    "plotter_widget.plotting_widget.active_artist.color_indices"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "array([1, 1, 0, 1, 1, 1, 0, 1, 0, 1, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1, 0, 0,\n",
-       "       0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 1, 1, 0, 1, 0, 0, 0, 0,\n",
-       "       0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0, 0, 1, 1, 0, 1, 1, 0, 1, 0, 0,\n",
-       "       1, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 1, 1, 0, 1,\n",
-       "       0, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0])"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "viewer.layers.selection.active = viewer.layers[0]\n",
-    "plotter_widget.plotting_widget.active_artist.color_indices"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>feature3</th>\n",
-       "      <th>feature2</th>\n",
-       "      <th>feature4</th>\n",
-       "      <th>layer</th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>0</th>\n",
-       "      <td>4.310577</td>\n",
-       "      <td>4.151826</td>\n",
-       "      <td>7.040538</td>\n",
-       "      <td>points</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>1</th>\n",
-       "      <td>5.776389</td>\n",
-       "      <td>5.125504</td>\n",
-       "      <td>5.937103</td>\n",
-       "      <td>points</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2</th>\n",
-       "      <td>7.000484</td>\n",
-       "      <td>5.524941</td>\n",
-       "      <td>4.011762</td>\n",
-       "      <td>points</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>3</th>\n",
-       "      <td>5.182016</td>\n",
-       "      <td>4.866394</td>\n",
-       "      <td>5.799276</td>\n",
-       "      <td>points</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>4</th>\n",
-       "      <td>5.402926</td>\n",
-       "      <td>5.967838</td>\n",
-       "      <td>5.933521</td>\n",
-       "      <td>points</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>195</th>\n",
-       "      <td>-6.577565</td>\n",
-       "      <td>-4.492556</td>\n",
-       "      <td>-3.971916</td>\n",
-       "      <td>points2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>196</th>\n",
-       "      <td>-4.782194</td>\n",
-       "      <td>-6.170168</td>\n",
-       "      <td>-4.662838</td>\n",
-       "      <td>points2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>197</th>\n",
-       "      <td>-5.848882</td>\n",
-       "      <td>-5.101038</td>\n",
-       "      <td>-5.075573</td>\n",
-       "      <td>points2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>198</th>\n",
-       "      <td>-6.524426</td>\n",
-       "      <td>-5.670933</td>\n",
-       "      <td>-7.476590</td>\n",
-       "      <td>points2</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>199</th>\n",
-       "      <td>-6.907373</td>\n",
-       "      <td>-5.843320</td>\n",
-       "      <td>-4.927803</td>\n",
-       "      <td>points2</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>200 rows × 4 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "     feature3  feature2  feature4    layer\n",
-       "0    4.310577  4.151826  7.040538   points\n",
-       "1    5.776389  5.125504  5.937103   points\n",
-       "2    7.000484  5.524941  4.011762   points\n",
-       "3    5.182016  4.866394  5.799276   points\n",
-       "4    5.402926  5.967838  5.933521   points\n",
-       "..        ...       ...       ...      ...\n",
-       "195 -6.577565 -4.492556 -3.971916  points2\n",
-       "196 -4.782194 -6.170168 -4.662838  points2\n",
-       "197 -5.848882 -5.101038 -5.075573  points2\n",
-       "198 -6.524426 -5.670933 -7.476590  points2\n",
-       "199 -6.907373 -5.843320 -4.927803  points2\n",
-       "\n",
-       "[200 rows x 4 columns]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "plotter_widget._get_features()"
    ]
   },
   {
@@ -602,7 +235,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.18"
+   "version": "3.12.9"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
@Cryaaa this PR fixes the `demo_new_plotter` notebook, where you encountered problems. The issue is simply that I left some old debug code of mine in there, which collides with some of the more recent changes at biaplotter and here. This should work - it's still demo, so I wouldn't know exactly what will happen if you execute the notebook from top to bottom and end up with totally different layers.

It's more meant to be used in a stop-and-go manner: Execute some cells to add a bit of data to the viewer, then play with the clusters plotter. 

### Copilot summary

This pull request includes several changes to the `notebooks/demo_new_plotter.ipynb` file, mainly focusing on updating output formats, warning messages, and code execution results. The most important changes include updating the output format for code cells, modifying warning messages, and removing unnecessary code cells.

Changes to output formats and warning messages:

* Updated the output format for code cells to include warning messages related to window geometry settings.
* Updated the warning messages to reflect changes in the file paths and the type of warnings being issued.

Code execution results and cleanup:

* Updated the memory addresses in the execution results to reflect the current state of the `Points` layer objects.
* Removed unnecessary code cells that displayed dataframes and arrays, cleaning up the notebook for better readability.

Version update:

* Updated the Python version in the notebook metadata from `3.9.18` to `3.12.9`.