### PR TITLE
Escape empty selection

### DIFF
--- a/src/napari_clusters_plotter/_algorithm_widget.py
+++ b/src/napari_clusters_plotter/_algorithm_widget.py
@@ -150,7 +150,7 @@ class AlgorithmWidgetBase(BaseWidget):
         if self.selected_algorithm_widget.data.value.empty:
             warnings.warn(
                 "No features selected. Please select features before running the algorithm.",
-                stacklevel=1
+                stacklevel=1,
             )
             return
         self.worker = worker

--- a/src/napari_clusters_plotter/_algorithm_widget.py
+++ b/src/napari_clusters_plotter/_algorithm_widget.py
@@ -149,7 +149,8 @@ class AlgorithmWidgetBase(BaseWidget):
         # escape empty input data
         if self.selected_algorithm_widget.data.value.empty:
             warnings.warn(
-                "No features selected. Please select features before running the algorithm."
+                "No features selected. Please select features before running the algorithm.",
+                stacklevel=1
             )
             return
         self.worker = worker

--- a/src/napari_clusters_plotter/_algorithm_widget.py
+++ b/src/napari_clusters_plotter/_algorithm_widget.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pandas as pd
 from magicgui import magicgui
 from napari.layers import (
@@ -15,7 +17,6 @@ from qtpy.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-import warnings
 
 
 class BaseWidget(QWidget):
@@ -50,7 +51,7 @@ class BaseWidget(QWidget):
                 "MANUAL_CLUSTER_ID"
             ].astype("category")
         return features.reset_index(drop=True)
-    
+
     def _clean_up(self):
         """Determines what happens in case of no layer selected"""
 

--- a/src/napari_clusters_plotter/_algorithm_widget.py
+++ b/src/napari_clusters_plotter/_algorithm_widget.py
@@ -49,6 +49,13 @@ class BaseWidget(QWidget):
                 "MANUAL_CLUSTER_ID"
             ].astype("category")
         return features.reset_index(drop=True)
+    
+    def _clean_up(self):
+        """Determines what happens in case of no layer selected"""
+
+        raise NotImplementedError(
+            "This function should be implemented in the subclass."
+        )
 
     @property
     def common_columns(self):

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -314,6 +314,7 @@ class PlotterWidget(BaseWidget):
         """
         # don't do anything if no layer is selected
         if self.n_selected_layers == 0:
+            self._clean_up()
             return
 
         # check if the selected layers are of the correct type
@@ -340,6 +341,23 @@ class PlotterWidget(BaseWidget):
 
         for layer in self.layers:
             layer.events.features.connect(self._update_feature_selection)
+
+    def _clean_up(self):
+        """In case of empty layer selection"""
+
+        # disconnect the events from the layers
+        for layer in self.viewer.layers.selection:
+            layer.events.features.disconnect(self._update_feature_selection)
+
+        # reset the selected layers
+        self.layers = []
+
+        # reset the selectors
+        for dim in ["x", "y", "hue"]:
+            selector = self._selectors[dim]
+            selector.blockSignals(True)
+            selector.clear()
+            selector.blockSignals(False)
 
     def _update_feature_selection(
         self, event: napari.utils.events.Event

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -146,6 +146,9 @@ class PlotterWidget(BaseWidget):
         # if the hue axis is not set to MANUAL_CLUSTER_ID, set it to that
         # otherwise replot the data
 
+        if self.n_selected_layers == 0:
+            return
+
         features = self._get_features()
         for layer in self.viewer.layers.selection:
             layer_indices = features[features["layer"] == layer.name].index
@@ -447,6 +450,10 @@ class PlotterWidget(BaseWidget):
         """
         Reset the selection in the current plotting widget.
         """
+
+        if self.n_selected_layers == 0:
+            return
+
         self.plotting_widget.active_artist.color_indices = np.zeros(
             len(self._get_features())
         )

--- a/src/napari_clusters_plotter/_tests/test_dimensionality_reduction.py
+++ b/src/napari_clusters_plotter/_tests/test_dimensionality_reduction.py
@@ -77,6 +77,11 @@ def test_initialization(make_napari_viewer, widget_config):
     # check that all features are in reduce_wdiget.feature_selection_widget
     assert len(feature_selection_items) == len(layer.features.columns)
 
+    # clear layers to make sure cleanup works
+    viewer.layers.clear()
+
+    assert widget.feature_selection_widget.count() == 0
+
 
 def test_layer_update(make_napari_viewer, widget_config):
     viewer = make_napari_viewer()

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -50,6 +50,7 @@ def create_multi_point_layer(n_samples: int = 100):
 
 def create_multi_vectors_layer(n_samples: int = 100):
     from napari.layers import Vectors
+
     points1, points2 = create_multi_point_layer(n_samples=n_samples)
 
     points_direction1 = np.random.normal(size=points1.data.shape)
@@ -187,7 +188,7 @@ def test_empty_layer_clean_up(make_napari_viewer, n_samples: int = 100):
     assert widget._selectors["y"].currentText() == ""
     assert widget._selectors["hue"].currentText() == ""
 
-    widget._reset()  
+    widget._reset()
 
     # add vectors to viewer
     viewer.add_layer(vectors1)

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -414,4 +414,3 @@ def test_temporal_highlighting(make_napari_viewer, create_sample_layers):
     # to highlight out-of and in-frame data points
     assert plotter_widget.plotting_widget.active_artist.alpha.min() == 0.25
     assert plotter_widget.plotting_widget.active_artist.size.min() == 35
-


### PR DESCRIPTION
Relevant for #378 

Hi @Cryaaa , this solves your problem. In essence, the logic on the napari side is safe, the problem was here: The case of an empty selection (after a previous non-empty selection) is not escaped anywhere in the widgets, so that's a pretty serious flaw you found :)

I added specific `_clean_up` methods that handle the teardown of any remaining references to previous layers as well as escape statements that check whether there is data in the viewer before trying to do anything. I wasn't able to completely clean up the plotter itself (i.e., the plotted data), but that's something to fix over at the biaplotter (see https://github.com/BiAPoL/biaplotter/issues/45).

### Copilot description

This pull request introduces several changes to the `napari_clusters_plotter` package, focusing on enhancing the handling of empty layer selections, adding new functionalities, and improving test coverage. The most significant changes include the implementation of `_clean_up` methods, adjustments to handle empty input data, and the addition of new tests.

Enhancements to handling empty layer selections:

* [`src/napari_clusters_plotter/_algorithm_widget.py`](diffhunk://#diff-a47db6b3042af68f2254073d1a78dfd5ee32b1913eb50534391995aedadf2430R54-R60): Added `_clean_up` method to handle cases with no selected layers and updated `_on_update_layer_selection` and `_wait_for_finish` methods to incorporate these changes. [[1]](diffhunk://#diff-a47db6b3042af68f2254073d1a78dfd5ee32b1913eb50534391995aedadf2430R54-R60) [[2]](diffhunk://#diff-a47db6b3042af68f2254073d1a78dfd5ee32b1913eb50534391995aedadf2430R148-R153) [[3]](diffhunk://#diff-a47db6b3042af68f2254073d1a78dfd5ee32b1913eb50534391995aedadf2430R181) [[4]](diffhunk://#diff-a47db6b3042af68f2254073d1a78dfd5ee32b1913eb50534391995aedadf2430R207-R216)
* [`src/napari_clusters_plotter/_new_plotter_widget.py`](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01R320): Introduced `_clean_up` method and updated `_on_update_layer_selection` and `_reset` methods to handle empty layer selections properly. [[1]](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01R320) [[2]](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01R348-R364) [[3]](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01R453-R456)

New functionalities:

* [`src/napari_clusters_plotter/_tests/test_plotter.py`](diffhunk://#diff-2d655e0941ae671331bd4bc1e0682a27920b236d70a1623496683969eaa87c04R51-R70): Added `create_multi_vectors_layer` function to facilitate the creation of vector layers for testing.

Test improvements:

* [`src/napari_clusters_plotter/_tests/test_dimensionality_reduction.py`](diffhunk://#diff-c2d582bf817c2b8e70e0a26c8066036c5d3daaa56514206383eebb929857cc60R80-R84): Enhanced `test_initialization` to clear layers and verify cleanup functionality.
* [`src/napari_clusters_plotter/_tests/test_plotter.py`](diffhunk://#diff-2d655e0941ae671331bd4bc1e0682a27920b236d70a1623496683969eaa87c04R155-R193): Added `test_empty_layer_clean_up` to ensure proper handling of layer deletions and additions.

These changes aim to improve the robustness and reliability of the `napari_clusters_plotter` package.