### PR TITLE
Make layer coloring more robust

### DIFF
--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -477,4 +477,3 @@ def _apply_layer_color(layer, colors):
         layer.colormap = DirectLabelColormap(color_dict=color_dict)
 
     layer.refresh()
-

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -464,9 +464,7 @@ def _apply_layer_color(layer, colors):
     elif isinstance(layer, napari.layers.Labels):
 
         colors = np.insert(colors, 0, [0, 0, 0, 0], axis=0)
-        color_dict = {
-            label: color for label, color in zip(np.unique(layer.data), colors)
-        }
+        color_dict = dict(zip(np.unique(layer.data), colors))
 
         # Insert default colors for labels that are not in the color_dict
         # Relevant for non-sequential label images

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -449,33 +449,32 @@ def _apply_layer_color(layer, colors):
     """
     from napari.utils import DirectLabelColormap
 
-    color_mapping = {
-        napari.layers.Points: lambda _layer, _color: setattr(
-            _layer, "face_color", _color
-        ),
-        napari.layers.Vectors: lambda _layer, _color: setattr(
-            _layer, "edge_color", _color
-        ),
-        napari.layers.Surface: lambda _layer, _color: setattr(
-            _layer, "vertex_colors", _color
-        ),
-        napari.layers.Shapes: lambda _layer, _color: setattr(
-            _layer, "face_color", _color
-        ),
-        napari.layers.Labels: lambda _layer, _color: setattr(
-            _layer,
-            "colormap",
-            DirectLabelColormap(
-                color_dict={
-                    label: _color[label] for label in np.unique(_layer.data)
-                }
-            ),
-        ),
-    }
+    if isinstance(layer, napari.layers.Points):
+        layer.face_color = colors
 
-    if type(layer) in color_mapping:
-        if type(layer) is napari.layers.Labels:
-            # add a color for the background at the first index
-            colors = np.insert(colors, 0, [0, 0, 0, 0], axis=0)
-        color_mapping[type(layer)](layer, colors)
-        layer.refresh()
+    elif isinstance(layer, napari.layers.Vectors):
+        layer.edge_color = colors
+
+    elif isinstance(layer, napari.layers.Surface):
+        layer.vertex_colors = colors
+
+    elif isinstance(layer, napari.layers.Shapes):
+        layer.face_color = colors
+
+    elif isinstance(layer, napari.layers.Labels):
+
+        colors = np.insert(colors, 0, [0, 0, 0, 0], axis=0)
+        color_dict = {
+            label: color for label, color in zip(np.unique(layer.data), colors)
+        }
+
+        # Insert default colors for labels that are not in the color_dict
+        # Relevant for non-sequential label images
+        if max(color_dict.keys()) > len(colors):
+            for i in range(1, max(color_dict.keys()) - 1):
+                color_dict[i] = [0, 0, 0, 0]
+        # Add a color for the background at the first index
+        layer.colormap = DirectLabelColormap(color_dict=color_dict)
+
+    layer.refresh()
+

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -123,7 +123,6 @@ def test_mixed_layers(make_napari_viewer):
     viewer.add_image(random_image)
     viewer.add_labels(sample_labels)
 
-    #
 
 @pytest.mark.parametrize(
     "create_sample_layers",
@@ -150,9 +149,8 @@ def test_cluster_memorization(make_napari_viewer, create_sample_layers):
     assert "MANUAL_CLUSTER_ID" in layer2.features.columns
 
     plotter_widget._selectors["x"].setCurrentText("feature3")
-    cluster_indeces = np.random.randint(0, 2, len(layer2.data))
-    layer2.features["MANUAL_CLUSTER_ID"] = cluster_indeces
-    plotter_widget._selectors["hue"].setCurrentText("MANUAL_CLUSTER_ID")
+    cluster_indeces = np.random.randint(0, 2, len(layer2.features))
+    plotter_widget._on_finish_draw(cluster_indeces)
 
     # select first layer and make sure that no clusters are selected
     viewer.layers.selection.active = layer

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -114,6 +114,50 @@ def create_multi_surface_layer(n_samples: int = 100):
     return surface1, surface2
 
 
+def create_multi_shapes_layers(n_samples: int = 100):
+    from napari.layers import Shapes
+
+    points1, points2 = create_multi_point_layer(n_samples=n_samples)
+
+    shapes1, shapes2 = [], []
+    for i in range(len(points1.data)):
+        # create a random shape around the point, whereas the shape consists of the coordinates
+        # of the four corner of the rectangle
+        y, x = points1.data[i, 2], points1.data[i, 3]
+        w, h = np.random.randint(1, 5), np.random.randint(1, 5)
+
+        shape1 = np.array(
+            [
+                [y - h, x - w],
+                [y - h, x + w],
+                [y + h, x + w],
+                [y + h, x - w],
+            ]
+        )
+        shapes1.append(shape1)
+
+    for i in range(len(points2.data)):
+        # create a random shape around the point, whereas the shape consists of the coordinates
+        # of the four corner of the rectangle
+        y, x = points2.data[i, 2], points2.data[i, 3]
+        w, h = np.random.randint(1, 5), np.random.randint(1, 5)
+
+        shape2 = np.array(
+            [
+                [y - h, x - w],
+                [y - h, x + w],
+                [y + h, x + w],
+                [y + h, x - w],
+            ]
+        )
+        shapes2.append(shape2)
+
+    shape1 = Shapes(shapes1, features=points1.features, name="shapes1")
+    shape2 = Shapes(shapes2, features=points2.features, name="shapes2", translate=(0, 2))
+
+    return shape1, shape2
+
+
 def create_multi_labels_layer():
     from skimage import data, measure
     from napari.layers import Labels
@@ -175,6 +219,7 @@ def test_mixed_layers(make_napari_viewer):
         create_multi_labels_layer,
         create_multi_vectors_layer,
         create_multi_surface_layer,
+        create_multi_shapes_layers
     ],
 )
 def test_cluster_memorization(make_napari_viewer, create_sample_layers):
@@ -219,6 +264,7 @@ def test_cluster_memorization(make_napari_viewer, create_sample_layers):
         create_multi_labels_layer,
         create_multi_vectors_layer,
         create_multi_surface_layer,
+        create_multi_shapes_layers
     ],
 )
 def test_categorical_handling(make_napari_viewer, create_sample_layers):

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -70,6 +70,50 @@ def create_multi_vectors_layer(n_samples: int = 100):
     return vectors1, vectors2
 
 
+def create_multi_surface_layer(n_samples: int = 100):
+    from napari.layers import Surface
+    
+    vertices1, vertices2 = create_multi_point_layer(n_samples=n_samples)
+
+    faces1 = []
+    faces2 = []
+    for t in range(int(vertices1.data[:, 0].max())):
+        vertex_indeces_t = np.argwhere(
+            vertices1.data[:, 0] == t
+        ).flatten()
+
+        # draw some random triangles from the indeces
+        _faces = np.random.randint(low=vertex_indeces_t.min(),
+                                   high=vertex_indeces_t.max(), size=(10, 3))
+        faces1.append(_faces)
+
+        vertex_indeces_t = np.argwhere(
+            vertices2.data[:, 0] == t
+        ).flatten()
+
+        # draw some random triangles from the indeces
+        _faces = np.random.randint(low=vertex_indeces_t.min(),
+                                   high=vertex_indeces_t.max(), size=(10, 3))
+        faces2.append(_faces)
+
+    faces1 = np.concatenate(faces1, axis=0)
+    faces2 = np.concatenate(faces2, axis=0)
+
+    surface1 = Surface(
+        (vertices1.data, faces1),
+        features=vertices1.features,
+        name="surface1",
+    )
+
+    surface2 = Surface(
+        (vertices2.data, faces2),
+        features=vertices2.features,
+        name="surface2",
+        translate=(0, 0, 2),
+    )
+    return surface1, surface2
+
+
 def create_multi_labels_layer():
     from skimage import data, measure
     from napari.layers import Labels
@@ -130,6 +174,7 @@ def test_mixed_layers(make_napari_viewer):
         create_multi_point_layer,
         create_multi_labels_layer,
         create_multi_vectors_layer,
+        create_multi_surface_layer,
     ],
 )
 def test_cluster_memorization(make_napari_viewer, create_sample_layers):
@@ -173,6 +218,7 @@ def test_cluster_memorization(make_napari_viewer, create_sample_layers):
         create_multi_point_layer,
         create_multi_labels_layer,
         create_multi_vectors_layer,
+        create_multi_surface_layer,
     ],
 )
 def test_categorical_handling(make_napari_viewer, create_sample_layers):

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -72,28 +72,30 @@ def create_multi_vectors_layer(n_samples: int = 100):
 
 def create_multi_surface_layer(n_samples: int = 100):
     from napari.layers import Surface
-    
+
     vertices1, vertices2 = create_multi_point_layer(n_samples=n_samples)
 
     faces1 = []
     faces2 = []
     for t in range(int(vertices1.data[:, 0].max())):
-        vertex_indeces_t = np.argwhere(
-            vertices1.data[:, 0] == t
-        ).flatten()
+        vertex_indeces_t = np.argwhere(vertices1.data[:, 0] == t).flatten()
 
         # draw some random triangles from the indeces
-        _faces = np.random.randint(low=vertex_indeces_t.min(),
-                                   high=vertex_indeces_t.max(), size=(10, 3))
+        _faces = np.random.randint(
+            low=vertex_indeces_t.min(),
+            high=vertex_indeces_t.max(),
+            size=(10, 3),
+        )
         faces1.append(_faces)
 
-        vertex_indeces_t = np.argwhere(
-            vertices2.data[:, 0] == t
-        ).flatten()
+        vertex_indeces_t = np.argwhere(vertices2.data[:, 0] == t).flatten()
 
         # draw some random triangles from the indeces
-        _faces = np.random.randint(low=vertex_indeces_t.min(),
-                                   high=vertex_indeces_t.max(), size=(10, 3))
+        _faces = np.random.randint(
+            low=vertex_indeces_t.min(),
+            high=vertex_indeces_t.max(),
+            size=(10, 3),
+        )
         faces2.append(_faces)
 
     faces1 = np.concatenate(faces1, axis=0)
@@ -153,15 +155,17 @@ def create_multi_shapes_layers(n_samples: int = 100):
         shapes2.append(shape2)
 
     shape1 = Shapes(shapes1, features=points1.features, name="shapes1")
-    shape2 = Shapes(shapes2, features=points2.features, name="shapes2", translate=(0, 2))
+    shape2 = Shapes(
+        shapes2, features=points2.features, name="shapes2", translate=(0, 2)
+    )
 
     return shape1, shape2
 
 
 def create_multi_labels_layer():
-    from skimage import data, measure
-    from napari.layers import Labels
     import pandas as pd
+    from napari.layers import Labels
+    from skimage import data, measure
 
     labels1 = measure.label(data.binary_blobs(length=64, n_dim=2))
     labels2 = measure.label(data.binary_blobs(length=64, n_dim=2))
@@ -183,7 +187,9 @@ def create_multi_labels_layer():
     )
 
     labels1 = Labels(labels1, name="labels1", features=features1)
-    labels2 = Labels(labels2, name="labels2", features=features2, translate=(0, 128))
+    labels2 = Labels(
+        labels2, name="labels2", features=features2, translate=(0, 128)
+    )
 
     return labels1, labels2
 
@@ -219,7 +225,7 @@ def test_mixed_layers(make_napari_viewer):
         create_multi_labels_layer,
         create_multi_vectors_layer,
         create_multi_surface_layer,
-        create_multi_shapes_layers
+        create_multi_shapes_layers,
     ],
 )
 def test_cluster_memorization(make_napari_viewer, create_sample_layers):
@@ -264,7 +270,7 @@ def test_cluster_memorization(make_napari_viewer, create_sample_layers):
         create_multi_labels_layer,
         create_multi_vectors_layer,
         create_multi_surface_layer,
-        create_multi_shapes_layers
+        create_multi_shapes_layers,
     ],
 )
 def test_categorical_handling(make_napari_viewer, create_sample_layers):

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 
 def create_multi_point_layer(n_samples: int = 100):
@@ -124,12 +125,19 @@ def test_mixed_layers(make_napari_viewer):
 
     #
 
-
-def test_cluster_memorization(make_napari_viewer, n_samples: int = 100):
+@pytest.mark.parametrize(
+    "create_sample_layers",
+    [
+        create_multi_point_layer,
+        create_multi_labels_layer,
+        create_multi_vectors_layer,
+    ],
+)
+def test_cluster_memorization(make_napari_viewer, create_sample_layers):
     from napari_clusters_plotter import PlotterWidget
 
     viewer = make_napari_viewer()
-    layer, layer2 = create_multi_point_layer(n_samples=n_samples)
+    layer, layer2 = create_sample_layers()
 
     # add layers to viewer
     viewer.add_layer(layer)
@@ -161,11 +169,19 @@ def test_cluster_memorization(make_napari_viewer, n_samples: int = 100):
     )
 
 
-def test_categorical_handling(make_napari_viewer, n_samples: int = 100):
+@pytest.mark.parametrize(
+    "create_sample_layers",
+    [
+        create_multi_point_layer,
+        create_multi_labels_layer,
+        create_multi_vectors_layer,
+    ],
+)
+def test_categorical_handling(make_napari_viewer, create_sample_layers):
     from napari_clusters_plotter import PlotterWidget
 
     viewer = make_napari_viewer()
-    layer, layer2 = create_multi_point_layer(n_samples=n_samples)
+    layer, layer2 = create_sample_layers()
 
     # add layers to viewer
     viewer.add_layer(layer)

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -48,6 +48,57 @@ def create_multi_point_layer(n_samples: int = 100):
     return layer, layer2
 
 
+def create_multi_vectors_layer(n_samples: int = 100):
+    from napari.layers import Vectors
+
+    points1, points2 = create_multi_point_layer(n_samples=n_samples)
+
+    points_direction1 = np.random.normal(size=points1.data.shape)
+    points_direction2 = np.random.normal(size=points2.data.shape)
+
+    # set time index correctly
+    points_direction1[:, 0] = points1.data[:, 0]
+    points_direction2[:, 0] = points2.data[:, 1]
+
+    vectors1 = np.stack([points1.data, points_direction1], axis=1)
+    vectors2 = np.stack([points2.data, points_direction2], axis=1)
+
+    vectors1 = Vectors(vectors1, features=points1.features, name="vectors1")
+    vectors2 = Vectors(vectors2, features=points2.features, name="vectors2")
+
+    return vectors1, vectors2
+
+
+def create_multi_labels_layer():
+    from skimage import data, measure
+    from napari.layers import Labels
+    import pandas as pd
+
+    labels1 = measure.label(data.binary_blobs(length=64, n_dim=2))
+    labels2 = measure.label(data.binary_blobs(length=64, n_dim=2))
+
+    features1 = pd.DataFrame(
+        {
+            "feature1": np.random.normal(size=labels1.max() + 1),
+            "feature2": np.random.normal(size=labels1.max() + 1),
+            "feature3": np.random.normal(size=labels1.max() + 1),
+        }
+    )
+
+    features2 = pd.DataFrame(
+        {
+            "feature1": np.random.normal(size=labels2.max() + 1),
+            "feature2": np.random.normal(size=labels2.max() + 1),
+            "feature3": np.random.normal(size=labels2.max() + 1),
+        }
+    )
+
+    labels1 = Labels(labels1, name="labels1", features=features1)
+    labels2 = Labels(labels2, name="labels2", features=features2, translate=(0, 128))
+
+    return labels1, labels2
+
+
 def test_mixed_layers(make_napari_viewer):
     from napari_clusters_plotter import PlotterWidget
 


### PR DESCRIPTION
This pull request introduces significant changes to the `napari_clusters_plotter` package, focusing on refactoring the `_apply_layer_color` function and enhancing the test suite with new layer creation functions and parameterized tests.

Refactoring `_apply_layer_color` function:

* [`src/napari_clusters_plotter/_new_plotter_widget.py`](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01L452-R480): Simplified the `_apply_layer_color` function by replacing the `color_mapping` dictionary with a series of `if-elif` statements to handle different layer types directly. This change improves readability and maintainability.

Enhancing the test suite:

* [`src/napari_clusters_plotter/_tests/test_plotter.py`](diffhunk://#diff-2d655e0941ae671331bd4bc1e0682a27920b236d70a1623496683969eaa87c04R2): Added the `pytest` import to facilitate parameterized tests.
* [`src/napari_clusters_plotter/_tests/test_plotter.py`](diffhunk://#diff-2d655e0941ae671331bd4bc1e0682a27920b236d70a1623496683969eaa87c04R52-R190): Introduced new functions (`create_multi_vectors_layer`, `create_multi_surface_layer`, `create_multi_shapes_layers`, `create_multi_labels_layer`) to create various types of layers for testing. These functions help in generating test data for different layer types.
* [`src/napari_clusters_plotter/_tests/test_plotter.py`](diffhunk://#diff-2d655e0941ae671331bd4bc1e0682a27920b236d70a1623496683969eaa87c04L74-R229): Updated `test_cluster_memorization` and `test_categorical_handling` to use `pytest.mark.parametrize` for testing multiple layer types, improving test coverage and robustness. [[1]](diffhunk://#diff-2d655e0941ae671331bd4bc1e0682a27920b236d70a1623496683969eaa87c04L74-R229) [[2]](diffhunk://#diff-2d655e0941ae671331bd4bc1e0682a27920b236d70a1623496683969eaa87c04L113-R274)
* [`src/napari_clusters_plotter/_tests/test_plotter.py`](diffhunk://#diff-2d655e0941ae671331bd4bc1e0682a27920b236d70a1623496683969eaa87c04L94-R243): Modified `test_cluster_memorization` to use `_on_finish_draw` method for setting cluster indices, ensuring consistency in how clusters are handled in tests.