### PR TITLE
added clustering and dimensionality reduction to NAP6 menus

### DIFF
--- a/src/napari_clusters_plotter/napari.yaml
+++ b/src/napari_clusters_plotter/napari.yaml
@@ -28,9 +28,20 @@ contributions:
   menus:
     napari/layers/visualize:
       - submenu: features_submenu
-
     features_submenu:
       - command: napari-clusters-plotter.plotter
+
+    napari/layers/transform:
+      - submenu: features_submenu
+    features_submenu:
+      - command: napari-clusters-plotter.Dimensionality_Reduction
+
+    napari/layers/classify:
+      - submenu: features_submenu
+    features_submenu:
+      - command: napari-clusters-plotter.Clustering
+
+    
 
   widgets:
     - command: napari-clusters-plotter.plotter

--- a/src/napari_clusters_plotter/napari.yaml
+++ b/src/napari_clusters_plotter/napari.yaml
@@ -41,10 +41,10 @@ contributions:
       display_name: Plot & select features
     - command: napari-clusters-plotter.Dimensionality_Reduction
       autogenerate: false
-      display_name: Dimensionality reduction on features
+      display_name: Dimensionality reduction (features)
     - command: napari-clusters-plotter.Clustering
       autogenerate: false
-      display_name: Clustering on features
+      display_name: Clustering (features)
 
   sample_data:
   - command: napari-clusters-plotter.bbbc_sample_data

--- a/src/napari_clusters_plotter/napari.yaml
+++ b/src/napari_clusters_plotter/napari.yaml
@@ -27,36 +27,24 @@ contributions:
 
   menus:
     napari/layers/visualize:
-      - submenu: features_submenu
-    features_submenu:
       - command: napari-clusters-plotter.plotter
 
-    napari/layers/transform:
-      - submenu: features_submenu
-    features_submenu:
+    napari/layers/project:
       - command: napari-clusters-plotter.Dimensionality_Reduction
 
     napari/layers/classify:
-      - submenu: features_submenu
-    features_submenu:
       - command: napari-clusters-plotter.Clustering
-
-
 
   widgets:
     - command: napari-clusters-plotter.plotter
       autogenerate: false
-      display_name: Clusters Plotter
+      display_name: Plot & select features
     - command: napari-clusters-plotter.Dimensionality_Reduction
       autogenerate: false
-      display_name: Dimensionality Reduction
+      display_name: Dimensionality reduction on features
     - command: napari-clusters-plotter.Clustering
       autogenerate: false
-      display_name: Clustering
-
-  submenus:
-    - id : features_submenu
-      label: Features
+      display_name: Clustering on features
 
   sample_data:
   - command: napari-clusters-plotter.bbbc_sample_data

--- a/src/napari_clusters_plotter/napari.yaml
+++ b/src/napari_clusters_plotter/napari.yaml
@@ -41,7 +41,7 @@ contributions:
     features_submenu:
       - command: napari-clusters-plotter.Clustering
 
-    
+
 
   widgets:
     - command: napari-clusters-plotter.plotter

--- a/src/napari_clusters_plotter/napari.yaml
+++ b/src/napari_clusters_plotter/napari.yaml
@@ -29,7 +29,7 @@ contributions:
     napari/layers/visualize:
       - command: napari-clusters-plotter.plotter
 
-    napari/layers/project:
+    napari/layers/measure:
       - command: napari-clusters-plotter.Dimensionality_Reduction
 
     napari/layers/classify:


### PR DESCRIPTION
Ok, this will put the widgets (plotter, dim. reduction & clustering) into the [contributable menus section](https://napari.org/stable/naps/6-contributable-menus.html). The Plotter itself was there before, but this brings the dim. reductoon and the clustering, too. In 0.9.0, they will then be found here:

- Plotter: `Layers > Visualize > Plot & select features (napari clusters plotter)`
- Dim. reduction `Layers > Project > Dimensionality reduction on features (napari clusters plotter)`
- Clustering: `Layers > Classify > Clustering on features (napari clusters plotter)`

@jni since you were asking about this on bsky the other day I'd guess I'd ping you, too as an additional pair of eyes ;) Do you think that'd be the appropriate place to put these?

## Long copilot description
This pull request updates the `napari.yaml` configuration for the `napari_clusters_plotter` plugin to reorganize menus, enhance clarity in widget display names, and remove unused submenus. Below are the key changes:

### Menu Reorganization:
* Added new menu entries under `napari/layers/project` and `napari/layers/classify` for `Dimensionality_Reduction` and `Clustering` commands, respectively.
* Removed the `features_submenu` and its associated entries to simplify the menu structure.

### Widget Display Name Updates:
* Updated widget display names for better clarity:
  - Changed "Clusters Plotter" to "Plot & select features."
  - Changed "Dimensionality Reduction" to "Dimensionality reduction on features."
  - Changed "Clustering" to "Clustering on features."