### PR TITLE
remove tools-menu and skimage regionprops

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,6 @@ dependencies = [
     "scikit-learn",
     "pandas",
     "umap-learn",
-    "napari-tools-menu",
-    "napari-skimage-regionprops>=0.3.1",
     "scikit-image",
     "scipy",
     "biaplotter>=0.2.0",


### PR DESCRIPTION
With #392 on its way, I think we don't need the napari-skimage and toolsmenu dependencies any more. Where measureing features is concerned, we could recommend a few tools in the documentation though. Among these I would list napari-skimage-regionprops, but also others, such as [napari-skimage](https://github.com/guiwitz/napari-skimage), which also offers support for regionprops as of lately.

As for the table display functionality, I think we may get this as a [built-in in napari](https://github.com/napari/napari/pull/7877) sometimes soon :)