### PR TITLE
Refactor some functions in histogram tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
     "napari-skimage-regionprops>=0.3.1",
     "scikit-image",
     "scipy",
-    "biaplotter>=0.3.1"
+    "biaplotter@git+https://github.com/biapol/biaplotter.git@fix_overlay_bug2",
 ]
 
 

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -634,7 +634,7 @@ class PlotterWidget(BaseWidget):
                 layer_indices = features[
                     features["layer"] == selected_layer.name
                 ].index
-                self._set_layer_color(selected_layer, rgba_colors[layer_indices])
+                _apply_layer_color(selected_layer, rgba_colors[layer_indices])
 
                 # Update MANUAL_CLUSTER_ID if applicable
                 if self.hue_axis == "MANUAL_CLUSTER_ID":
@@ -644,42 +644,14 @@ class PlotterWidget(BaseWidget):
             else:
                 # Apply default colors
                 rgba_colors = self._generate_default_colors(selected_layer)
-                self._set_layer_color(selected_layer, rgba_colors)
+                _apply_layer_color(selected_layer, rgba_colors)
 
         # Apply default colors to layers being unselected
         for layer in self.layers_being_unselected:
             if layer in self.viewer.layers:
                 rgba_colors = self._generate_default_colors(layer)
-                self._set_layer_color(layer, rgba_colors)
+                _apply_layer_color(layer, rgba_colors)
         self.layers_being_unselected = []
-
-    def _set_layer_color(self, layer, colors):
-        """
-        Set colors for a specific layer based on its type.
-
-        Parameters
-        ----------
-        layer : napari.layers.Layer
-            The layer to color.
-
-        colors : np.ndarray
-            The color array (Nx4).
-        """
-        if isinstance(layer, napari.layers.Points):
-            layer.face_color = colors
-        elif isinstance(layer, napari.layers.Vectors):
-            layer.edge_color = colors
-        elif isinstance(layer, napari.layers.Surface):
-            layer.vertex_colors = colors
-        elif isinstance(layer, napari.layers.Shapes):
-            layer.face_color = colors
-        elif isinstance(layer, napari.layers.Labels):
-            # Ensure the first color is transparent for the background
-            colors = np.insert(colors, 0, [0, 0, 0, 0], axis=0)
-            from napari.utils import DirectLabelColormap
-            color_dict = dict(zip(np.unique(layer.data), colors))
-            layer.colormap = DirectLabelColormap(color_dict=color_dict)
-        layer.refresh()
 
     def _reset(self):
         """
@@ -692,3 +664,32 @@ class PlotterWidget(BaseWidget):
             len(self._get_features())
         )
         self._update_layer_colors(use_color_indices=False)
+
+
+def _apply_layer_color(layer, colors):
+    """
+    Set colors for a specific layer based on its type.
+
+    Parameters
+    ----------
+    layer : napari.layers.Layer
+        The layer to color.
+
+    colors : np.ndarray
+        The color array (Nx4).
+    """
+    if isinstance(layer, napari.layers.Points):
+        layer.face_color = colors
+    elif isinstance(layer, napari.layers.Vectors):
+        layer.edge_color = colors
+    elif isinstance(layer, napari.layers.Surface):
+        layer.vertex_colors = colors
+    elif isinstance(layer, napari.layers.Shapes):
+        layer.face_color = colors
+    elif isinstance(layer, napari.layers.Labels):
+        # Ensure the first color is transparent for the background
+        colors = np.insert(colors, 0, [0, 0, 0, 0], axis=0)
+        from napari.utils import DirectLabelColormap
+        color_dict = dict(zip(np.unique(layer.data), colors))
+        layer.colormap = DirectLabelColormap(color_dict=color_dict)
+    layer.refresh()

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -498,10 +498,9 @@ class PlotterWidget(BaseWidget):
                 ).astype("category")
 
         self.layers = list(self.viewer.layers.selection)
-        if event is not None:
-            if len(event.removed) > 0:
-                # remove the layers that are not in the selection anymore
-                self.layers_being_unselected = list(event.removed)
+        if event is not None and len(event.removed) > 0:
+            # remove the layers that are not in the selection anymore
+            self.layers_being_unselected = list(event.removed)
         self._update_feature_selection(None)
 
         for layer in self.layers:

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -626,25 +626,26 @@ class PlotterWidget(BaseWidget):
         active_artist = self.plotting_widget.active_artist
 
         for selected_layer in self.viewer.layers.selection:
-            if use_color_indices:
-                # Apply colors based on color indices
-                rgba_colors = active_artist.color_indices_to_rgba(
-                    active_artist.color_indices
-                )
-                layer_indices = features[
-                    features["layer"] == selected_layer.name
-                ].index
-                _apply_layer_color(selected_layer, rgba_colors[layer_indices])
-
-                # Update MANUAL_CLUSTER_ID if applicable
-                if self.hue_axis == "MANUAL_CLUSTER_ID":
-                    selected_layer.features["MANUAL_CLUSTER_ID"] = pd.Series(
-                        active_artist.color_indices[layer_indices]
-                    ).astype("category")
-            else:
+            if not use_color_indices:
                 # Apply default colors
                 rgba_colors = self._generate_default_colors(selected_layer)
                 _apply_layer_color(selected_layer, rgba_colors)
+                continue
+
+            # Apply colors based on color indices
+            rgba_colors = active_artist.color_indices_to_rgba(
+                active_artist.color_indices
+            )
+            layer_indices = features[
+                features["layer"] == selected_layer.name
+            ].index
+            _apply_layer_color(selected_layer, rgba_colors[layer_indices])
+
+            # Update MANUAL_CLUSTER_ID if applicable
+            if self.hue_axis == "MANUAL_CLUSTER_ID":
+                selected_layer.features["MANUAL_CLUSTER_ID"] = pd.Series(
+                    active_artist.color_indices[layer_indices]
+                ).astype("category")
 
         # Apply default colors to layers being unselected
         for layer in self.layers_being_unselected:

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -164,7 +164,7 @@ class PlotterWidget(BaseWidget):
         for selector in self.plotting_widget.selectors.values():
             selector.selection_applied_signal.connect(self._on_finish_draw)
         self.plotting_widget.show_color_overlay_signal.connect(
-            self._on_show_plot_overlay
+            self._update_layer_colors
         )
 
         # connect scatter/histogram switch
@@ -574,12 +574,6 @@ class PlotterWidget(BaseWidget):
                 selector.setItemData(
                     index, "Categorical Column", Qt.ToolTipRole
                 )
-
-    def _on_show_plot_overlay(self, state: bool) -> None:
-        """
-        Called when the plot overlay is hidden or shown.
-        """
-        self._update_layer_colors(use_color_indices=state)
 
     def _generate_default_colors(self, layer):
         """


### PR DESCRIPTION
@zoccoler small refactoring changes to #390. I changed the baplotter dependency to the branch on the repo to make sure that tests can pass, will change it as soon as 0.3.1 is released.

PS: I tested the functionality manually and everything seems to work. Tests are passing locally.

## Long copilot description
This pull request refactors the color management logic in the `napari_clusters_plotter` widget to improve clarity and maintainability. Key changes include replacing redundant methods, simplifying color application, and introducing a new utility function for layer color updates.

### Refactoring and Simplification:

* Replaced the `_on_show_plot_overlay` method with a direct connection to `_update_layer_colors`, removing unnecessary indirection in handling the `show_color_overlay_signal`. [[1]](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01L167-R167) [[2]](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01L578-L583)
* Simplified the `_update_layer_colors` method by consolidating logic for applying default and indexed colors, and removing redundant code paths.

### Utility Function Addition:

* Introduced a new `_apply_layer_color` utility function to centralize the logic for applying colors to layers, improving code reuse and readability.

### Code Cleanup:

* Removed the `_set_layer_color` method and inlined its functionality into `_apply_layer_color`, as it was no longer needed.
* Eliminated the `_reset` method from its previous location and moved its functionality into a new definition, aligning it with the refactored `_update_layer_colors` logic. [[1]](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01L629-R664) [[2]](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01L683-L694)