### PR TITLE
Fix default color setting

### DIFF
--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -628,7 +628,8 @@ class PlotterWidget(BaseWidget):
             )  # rgba
         else:
             # Default to white for other layer types
-            return np.array([[1, 1, 1, 1]])
+            default_color = np.array([[1, 1, 1, 1]])
+            return default_color.repeat(len(layer.features), axis=0)
 
     def _update_layer_colors(self, use_color_indices: bool = False) -> None:
         """

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -180,6 +180,23 @@ def create_multi_surface_layer(n_samples: int = 100):
     return surface1, surface2
 
 
+def create_multi_surface_layer2():
+    from napari_clusters_plotter._sample_data import cells3d_curvatures
+    from napari.layers import Layer
+
+    layer1 = cells3d_curvatures()[1]
+    layer2 = cells3d_curvatures()[1]
+
+    layer1 = Layer.create(*layer1)
+    layer2 = Layer.create(*layer2)
+
+    #rename features to feature1, feature2, etc
+    layer1.features.columns = [f"feature{i}" for i in range(1, len(layer1.features.columns) + 1)]
+    layer2.features.columns = [f"feature{i}" for i in range(1, len(layer2.features.columns) + 1)]
+
+    return layer1, layer2
+
+
 def create_multi_shapes_layers(n_samples: int = 100):
     from napari.layers import Shapes
 
@@ -487,3 +504,33 @@ def test_histogram_support(make_napari_viewer, create_sample_layers):
     plotter_widget.control_widget.overlay_cmap_box.setCurrentText("viridis")
 
     plotter_widget.plotting_type = "SCATTER"
+
+
+@pytest.mark.parametrize(
+    "create_sample_layers",
+    [
+        create_multi_point_layer,
+        create_multi_vectors_layer,
+        create_multi_surface_layer,
+        create_multi_surface_layer2,
+        create_multi_shapes_layers,
+    ],
+)
+def test_cluster_visibility_toggle(make_napari_viewer, create_sample_layers):
+    from napari_clusters_plotter import PlotterWidget
+
+    viewer = make_napari_viewer()
+    viewer.dims.ndisplay = 3
+    
+    # add layers to viewer
+    layer, layer2 = create_sample_layers()
+    viewer.add_layer(layer)
+    viewer.add_layer(layer2)
+
+    plotter_widget = PlotterWidget(viewer)
+    viewer.window.add_dock_widget(plotter_widget, area="right")
+    plotter_widget._selectors["x"].setCurrentText("feature3")
+
+    plotter_widget._on_show_plot_overlay(state=False)
+    plotter_widget._on_show_plot_overlay(state=True)
+    plotter_widget._on_show_plot_overlay(state=False)

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -181,8 +181,9 @@ def create_multi_surface_layer(n_samples: int = 100):
 
 
 def create_multi_surface_layer2():
-    from napari_clusters_plotter._sample_data import cells3d_curvatures
     from napari.layers import Layer
+
+    from napari_clusters_plotter._sample_data import cells3d_curvatures
 
     layer1 = cells3d_curvatures()[1]
     layer2 = cells3d_curvatures()[1]
@@ -190,9 +191,13 @@ def create_multi_surface_layer2():
     layer1 = Layer.create(*layer1)
     layer2 = Layer.create(*layer2)
 
-    #rename features to feature1, feature2, etc
-    layer1.features.columns = [f"feature{i}" for i in range(1, len(layer1.features.columns) + 1)]
-    layer2.features.columns = [f"feature{i}" for i in range(1, len(layer2.features.columns) + 1)]
+    # rename features to feature1, feature2, etc
+    layer1.features.columns = [
+        f"feature{i}" for i in range(1, len(layer1.features.columns) + 1)
+    ]
+    layer2.features.columns = [
+        f"feature{i}" for i in range(1, len(layer2.features.columns) + 1)
+    ]
 
     return layer1, layer2
 
@@ -521,7 +526,7 @@ def test_cluster_visibility_toggle(make_napari_viewer, create_sample_layers):
 
     viewer = make_napari_viewer()
     viewer.dims.ndisplay = 3
-    
+
     # add layers to viewer
     layer, layer2 = create_sample_layers()
     viewer.add_layer(layer)


### PR DESCRIPTION
Fixes #400 

Essentially, passing a single color as a default for other layer types than Labels wasn't the right choice. Strangely, the error only shows when the dimensions displayed is 3D, which is a bit odd 🤔 

Anyway, this should fix it.


## Long description
This pull request introduces enhancements to the `napari_clusters_plotter` package, including improved color handling for layers, a new utility function for creating test layers, and a new parameterized test for cluster visibility toggling. Below are the most significant changes grouped by theme:

### Enhancements to Layer Color Handling
* Modified `_generate_default_colors` in `src/napari_clusters_plotter/_new_plotter_widget.py` to ensure the default white color is repeated for all features in a layer, improving compatibility with layers that have multiple features.

### Additions to Test Utilities
* Added `create_multi_surface_layer2` in `src/napari_clusters_plotter/_tests/test_plotter.py`, which creates two surface layers with renamed features for testing purposes. This enhances the flexibility of test layer creation.

### New Test for Cluster Visibility
* Introduced a parameterized test `test_cluster_visibility_toggle` in `src/napari_clusters_plotter/_tests/test_plotter.py`. This test validates the functionality of toggling cluster visibility across multiple layer types, ensuring robust behavior.