### PR TITLE
extend algorithm subwidgets with links to docs

### DIFF
--- a/docs/contributing/new_algorithm.md
+++ b/docs/contributing/new_algorithm.md
@@ -61,10 +61,26 @@ Once that is done, you need to make the method available for the clustering or d
 ```python
 class DimensionalityReductionWidget(AlgorithmWidgetBase):
     algorithms = {
-        "PCA": {"callback": reduce_pca, "column_string": "PC"},
-        "t-SNE": {"callback": reduce_tsne, "column_string": "t-SNE"},
-        "UMAP": {"callback": reduce_umap, "column_string": "UMAP"},
-        "My algorithm" : {"callback": reduce_my_algorithm, "column_string": "some_acronym_for_your_algorithm"}
+        "PCA": {
+            "callback": reduce_pca,
+            "column_string": "PC",
+            "doc_url": "https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html",
+        },
+        "t-SNE": {
+            "callback": reduce_tsne,
+            "column_string": "t-SNE",
+            "doc_url": "https://scikit-learn.org/stable/modules/generated/sklearn.manifold.TSNE.html",
+        },
+        "UMAP": {
+            "callback": reduce_umap,
+            "column_string": "UMAP",
+            "doc_url": "https://umap-learn.readthedocs.io/en/latest/",
+        },
+        "my-new-algorithm": {
+            "callback": reduce_my_algorithm,
+            "column_string": "acronym_of_my_algorithm",
+            "doc_url": "https://link-to-my-algorithm-that-explains-what-it-does.com"
+        }
     }
 
     def __init__(self, napari_viewer: napari.Viewer):
@@ -77,7 +93,7 @@ class DimensionalityReductionWidget(AlgorithmWidgetBase):
 
 ```
 
-The relevant parts here are to add the above-implemented function as a callback to the widget. Secondly, you'll need to provide an acronym for your algorithm. The reduced features will then appear in the list of features as `ACRONYM_0` and `ACRONYM_1` (e.g., `PC_0` and `PC_1` for PCA).
+The relevant parts here are to add the above-implemented function as a callback to the widget. Secondly, you'll need to provide an acronym for your algorithm. The reduced features will then appear in the list of features as `ACRONYM_0` and `ACRONYM_1` (e.g., `PC_0` and `PC_1` for PCA). Lastly, please add a link to a documentation page that describes how your algorithm works, what it does and what its parameters mean.
 
 ## New clustering algorithm
 

--- a/src/napari_clusters_plotter/_algorithm_widget.py
+++ b/src/napari_clusters_plotter/_algorithm_widget.py
@@ -162,11 +162,10 @@ class AlgorithmWidgetBase(BaseWidget):
             self.selected_algorithm_widget.native.deleteLater()
 
         algorithm = self.algorithm_selection.currentText()
-        init_function = lambda widget: self._on_init_algorithm(widget)
         widget_factory = magic_factory(
             self.algorithms[algorithm]["callback"],
             call_button="Run",
-            widget_init = init_function,
+            widget_init = lambda widget: self._on_init_algorithm(widget),
             )
         self.selected_algorithm_widget = widget_factory()
         self.selected_algorithm_widget.native_parent_changed.emit(self)

--- a/src/napari_clusters_plotter/_algorithm_widget.py
+++ b/src/napari_clusters_plotter/_algorithm_widget.py
@@ -176,6 +176,16 @@ class AlgorithmWidgetBase(BaseWidget):
         self._update_features()
 
     def _on_init_algorithm(self, widget):
+        """
+        Add a label with the documentation link to the algorithm widget.
+
+        Taken from https://github.com/guiwitz/napari-skimage/blob/main/src/napari_skimage/skimage_detection_widget.py
+
+        Parameters
+        ----------
+        widget : magicgui.widgets.Widget
+            The widget to add the label to.
+        """
         label_widget = Label(value='')
 
         algorithm = self.algorithms[self.algorithm_selection.currentText()]

--- a/src/napari_clusters_plotter/_dim_reduction_and_clustering.py
+++ b/src/napari_clusters_plotter/_dim_reduction_and_clustering.py
@@ -15,15 +15,25 @@ from ._algorithms import (
 
 class ClusteringWidget(AlgorithmWidgetBase):
     algorithms = {
-        "KMeans": {"callback": cluster_kmeans, "column_string": "KMeans"},
-        "HDBSCAN": {"callback": cluster_hdbscan, "column_string": "HDBSCAN"},
+        "KMeans": {
+            "callback": cluster_kmeans,
+            "column_string": "KMeans",
+            "doc_url": "https://scikit-learn.org/stable/modules/generated/sklearn.cluster.KMeans.html",
+            },
+        "HDBSCAN": {
+            "callback": cluster_hdbscan,
+            "column_string": "HDBSCAN",
+            "doc_url": "https://hdbscan.readthedocs.io/en/latest/how_hdbscan_works.html",
+            },
         "Gaussian Mixture": {
             "callback": cluster_gaussian_mixture,
             "column_string": "Gaussian Mixture",
+            "doc_url": "https://scikit-learn.org/stable/modules/generated/sklearn.mixture.GaussianMixture.html",
         },
         "Spectral": {
             "callback": cluster_spectral,
             "column_string": "Spectral",
+            "doc_url": "https://scikit-learn.org/stable/modules/generated/sklearn.cluster.SpectralClustering.html",
         },
     }
 
@@ -64,9 +74,22 @@ class ClusteringWidget(AlgorithmWidgetBase):
 
 class DimensionalityReductionWidget(AlgorithmWidgetBase):
     algorithms = {
-        "PCA": {"callback": reduce_pca, "column_string": "PC"},
-        "t-SNE": {"callback": reduce_tsne, "column_string": "t-SNE"},
-        "UMAP": {"callback": reduce_umap, "column_string": "UMAP"},
+        "PCA": {
+            "callback":
+            reduce_pca,
+            "column_string": "PC",
+            "doc_url": "https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html",
+            },
+        "t-SNE": {
+            "callback": reduce_tsne,
+            "column_string": "t-SNE",
+            "doc_url": "https://scikit-learn.org/stable/modules/generated/sklearn.manifold.TSNE.html",
+            },
+        "UMAP": {
+            "callback": reduce_umap,
+            "column_string": "UMAP",
+            "doc_url": "https://umap-learn.readthedocs.io/en/latest/",
+            },
     }
 
     def __init__(self, napari_viewer: napari.Viewer):


### PR DESCRIPTION
Just a small improvement: This PR adds links to the documentation of the respective algorithm to the algorithm widget. Need to update the documentation to include how to do this but I think this is already a very sleek improvement :)

This pull request introduces enhancements to the `napari_clusters_plotter` plugin by improving the algorithm widget's functionality and adding documentation links for algorithms. The most significant changes include migrating from `magicgui` to `magic_factory`, adding support for external documentation links in the UI, and updating the algorithm definitions to include `doc_url` fields.

### Enhancements to the algorithm widget:

* Replaced `magicgui` with `magic_factory` for creating algorithm widgets, allowing for more flexible widget initialization. A new `_on_init_algorithm` method was added to dynamically add a clickable documentation link to the widget. (`src/napari_clusters_plotter/_algorithm_widget.py`, [src/napari_clusters_plotter/_algorithm_widget.pyL164-R188](diffhunk://#diff-a47db6b3042af68f2254073d1a78dfd5ee32b1913eb50534391995aedadf2430L164-R188))
* Introduced a `Label` widget to display algorithm documentation links in the UI. The links are clickable and open in an external browser. (`src/napari_clusters_plotter/_algorithm_widget.py`, [src/napari_clusters_plotter/_algorithm_widget.pyL164-R188](diffhunk://#diff-a47db6b3042af68f2254073d1a78dfd5ee32b1913eb50534391995aedadf2430L164-R188))

### Addition of algorithm documentation links:

* Updated the `algorithms` dictionary in `ClusteringWidget` to include `doc_url` fields for each clustering algorithm, linking to their respective documentation. (`src/napari_clusters_plotter/_dim_reduction_and_clustering.py`, [src/napari_clusters_plotter/_dim_reduction_and_clustering.pyL18-R36](diffhunk://#diff-83cea866110aed63aaeabf03765385b2ac32b83774e8cc6a7da9244f7f75da2eL18-R36))
* Added `doc_url` fields to the `DimensionalityReductionWidget` algorithms, providing links to the documentation for PCA, t-SNE, and UMAP. (`src/napari_clusters_plotter/_dim_reduction_and_clustering.py`, [src/napari_clusters_plotter/_dim_reduction_and_clustering.pyL67-R92](diffhunk://#diff-83cea866110aed63aaeabf03765385b2ac32b83774e8cc6a7da9244f7f75da2eL67-R92))