### PR TITLE
Rename reset button

### DIFF
--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -723,3 +723,4 @@ class PlotterWidget(BaseWidget):
             len(self._get_features())
         )
         self._update_layer_colors(use_color_indices=False)
+        self.control_widget.hue_box.setCurrentText("MANUAL_CLUSTER_ID")

--- a/src/napari_clusters_plotter/plotter_inputs.ui
+++ b/src/napari_clusters_plotter/plotter_inputs.ui
@@ -70,7 +70,7 @@
        <item row="3" column="0" colspan="2">
         <widget class="QPushButton" name="reset_button">
          <property name="text">
-          <string>Reset</string>
+          <string>Clear Selection</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Fixes #411 

This pull request includes updates to the `napari_clusters_plotter` functionality, focusing on improving user interface clarity and ensuring consistent behavior when resetting the widget.

User interface improvements:

* [`src/napari_clusters_plotter/plotter_inputs.ui`](diffhunk://#diff-645a2abe2612eee86a0a584b4947fb59c3ccb8d0a32f987eac8e4c732a83cd9bL73-R73): Changed the text of the `reset_button` from "Reset" to "Clear Selection" to better reflect its functionality.

Behavioral consistency updates:

* [`src/napari_clusters_plotter/_new_plotter_widget.py`](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01R726): Modified the `_reset` method to set the `hue_box` control widget's current text to "MANUAL_CLUSTER_ID," ensuring consistent behavior when resetting the widget.