### PR TITLE
Add axes label text

### DIFF
--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -232,6 +232,18 @@ class PlotterWidget(BaseWidget):
             self.control_widget.cmap_container.setVisible(False)
             self.control_widget.bins_settings_container.setVisible(False)
 
+    def _reset_axes_labels(self):
+        """
+        Clear the x and y axis labels in the plotting widget.
+        """
+        for artist in self.plotting_widget.artists.values():
+            if hasattr(artist, "x_label"):
+                artist.x_label_text = ""
+                artist.x_label_color = "white"
+            if hasattr(artist, "y_label"):
+                artist.y_label_text = ""
+                artist.y_label_color = "white"
+
     def _replot(self):
         """
         Replot the data with the current settings.

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -60,6 +60,7 @@ class PlotterWidget(BaseWidget):
                 self.overlay_colormap_plot
             ),
         }
+        self._replot()
 
     def _napari_to_mpl_cmap(self, colormap_name):
         return LinearSegmentedColormap.from_list(

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -263,8 +263,10 @@ class PlotterWidget(BaseWidget):
             (self.hue_axis in self.categorical_columns, self.plotting_type)
         ]
         self._handle_advanced_options_widget_visibility()
-
+        self._reset_axes_labels()
         active_artist = self.plotting_widget.active_artist
+        active_artist.x_label_text = self.x_axis
+        active_artist.y_label_text = self.y_axis
         color_norm = "log" if self.log_scale else "linear"
         # First set the data related properties in the active artist
         active_artist.data = np.stack([x_data, y_data], axis=1)


### PR DESCRIPTION
This pull request introduces functionality to manage axis labels in the plotting widget of `napari_clusters_plotter`. The changes focus on improving the clarity of the plots by resetting and updating axis labels during replotting.

Axis label management:

* [`src/napari_clusters_plotter/_new_plotter_widget.py`](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01R235-R246): Added a new method `_reset_axes_labels` to clear existing x and y axis labels for all artists in the plotting widget. This ensures the labels are reset before replotting.
* [`src/napari_clusters_plotter/_new_plotter_widget.py`](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01L254-R269): Updated the `_replot` method to call `_reset_axes_labels` and set new x and y axis labels based on the current settings. This enhances the dynamic updating of axis labels during replotting.