### PR TITLE
allow derived layers as input types

### DIFF
--- a/src/napari_clusters_plotter/_algorithm_widget.py
+++ b/src/napari_clusters_plotter/_algorithm_widget.py
@@ -86,8 +86,16 @@ class BaseWidget(QWidget):
         return [
             layer
             for layer in self.viewer.layers.selection
-            if type(layer) in self.input_layer_types
+            if self._is_supported_layer(layer)
         ]
+    
+    def _is_supported_layer(self, layer: 'napari.layers.Layer') -> bool:
+        """
+        Check if the layer is of a supported type. Supported types are
+        Labels, Points, Shapes, Surface, Tracks, and Vectors as well as
+        any custom layer that inherits from these types.
+        """
+        return any(isinstance(layer, layer_type) for layer_type in self.input_layer_types)
 
 
 class AlgorithmWidgetBase(BaseWidget):

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -689,7 +689,7 @@ class PlotterWidget(BaseWidget):
         for layer in self.layers_being_unselected:
             if (
                 layer in self.viewer.layers
-                and type(layer) in self.input_layer_types
+                and self._is_supported_layer(layer)
             ):
                 rgba_colors = self._generate_default_colors(layer)
                 self._set_layer_color(layer, rgba_colors)


### PR DESCRIPTION
This pull request refactors the logic for determining supported layer types in the `napari_clusters_plotter` package by introducing a new helper method, `_is_supported_layer`. This change improves code readability and maintainability by centralizing the logic for checking layer compatibility.

### Refactoring for layer type checks:

* [`src/napari_clusters_plotter/_algorithm_widget.py`](diffhunk://#diff-a47db6b3042af68f2254073d1a78dfd5ee32b1913eb50534391995aedadf2430L89-R99): Replaced the inline type-checking logic in `get_valid_layers` with a call to the newly introduced `_is_supported_layer` method. The `_is_supported_layer` method checks if a layer is of a supported type, including custom layers inheriting from supported base types.
* [`src/napari_clusters_plotter/_new_plotter_widget.py`](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01L692-R692): Updated the `_update_layer_colors` method to use `_is_supported_layer` for consistency with the refactored logic.