### PR TITLE
add min_dist to umap parameters

### DIFF
--- a/src/napari_clusters_plotter/_algorithms.py
+++ b/src/napari_clusters_plotter/_algorithms.py
@@ -90,7 +90,7 @@ def reduce_umap(
         n_components: int,
         n_neighbors: int,
         min_dist: float,
-        scale: bool
+        scale: bool,
     ) -> pd.DataFrame:
         import umap
         from sklearn.preprocessing import StandardScaler
@@ -106,7 +106,8 @@ def reduce_umap(
         reducer = umap.UMAP(
             n_components=n_components,
             n_neighbors=n_neighbors,
-            min_dist=min_dist)
+            min_dist=min_dist,
+        )
         reduced_data = reducer.fit_transform(preprocessed)
 
         # Add NaN rows back


### PR DESCRIPTION
This pull request updates the `reduce_umap` function in `src/napari_clusters_plotter/_algorithms.py` to include a new parameter, `min_dist`, for enhanced control over the UMAP dimensionality reduction process. The changes ensure that the `min_dist` parameter is passed through all relevant layers of the function and applied in the UMAP reducer configuration.

- [x] Checked interactively

Enhancements to UMAP dimensionality reduction:

* Added a `min_dist` parameter to the `reduce_umap` function signature to allow users to specify the minimum distance between points in the reduced space. 
* Updated the `_reduce_umap` function signature to include the `min_dist` parameter, ensuring it is passed correctly.
* Modified the UMAP reducer instantiation to use the `min_dist` parameter, enabling its functionality during dimensionality reduction.
* Adjusted the return statement of the `reduce_umap` function to pass the `min_dist` parameter to `_reduce_umap`.