### PR TITLE
Improve scatter ux

### DIFF
--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -45,6 +45,10 @@ class PlotterWidget(BaseWidget):
         self.layers_being_unselected = []
         self._on_update_layer_selection(None)
         self._setup_callbacks()
+        
+        # some default values
+        self._out_of_frame_alpha = 0.25
+        self._out_of_frame_size_factor = 0.5
 
         self.plot_needs_update.connect(self._replot)
 
@@ -317,8 +321,8 @@ class PlotterWidget(BaseWidget):
             size = np.ones(len(alpha)) * self.scatter_point_size
 
             index_out_of_frame = alpha == 0
-            alpha[index_out_of_frame] = 0.25
-            size[index_out_of_frame] = self.scatter_point_size * 0.5
+            alpha[index_out_of_frame] = self._out_of_frame_alpha
+            size[index_out_of_frame] = self.scatter_point_size * self._out_of_frame_size_factor
             self.plotting_widget.active_artist.alpha = alpha
             self.plotting_widget.active_artist.size = size
 

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -281,6 +281,11 @@ class PlotterWidget(BaseWidget):
             active_artist.bins = self.bin_number
             active_artist.histogram_color_normalization_method = color_norm
 
+        else:
+            # make sure we use the correct frame highlighting settings
+            self._on_frame_highlighting_toggled()
+            self._on_point_size_changed()
+
         # Then set color_indices and colormap properties in the active artist
         active_artist.overlay_colormap = overlay_cmap
         active_artist.color_indices = features[self.hue_axis].to_numpy()
@@ -558,9 +563,6 @@ class PlotterWidget(BaseWidget):
                 Warning(
                     f"Layer {layer.name} does not have events.features or events.properties"
                 )
-
-        # make sure we use the correct frame highlighting settings
-        self._on_frame_highlighting_toggled()
 
     def _clean_up(self):
         """In case of empty layer selection"""

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -186,6 +186,10 @@ class PlotterWidget(BaseWidget):
             self._on_frame_highlighting_toggled
         )
 
+        self.control_widget.spinBox_point_size.valueChanged.connect(
+            self._on_point_size_changed
+        )
+
     def _on_finish_draw(self, color_indices: np.ndarray):
         """
         Called when user finsihes drawing. Will change the hue combo box to the
@@ -310,11 +314,11 @@ class PlotterWidget(BaseWidget):
             alpha = np.asarray(
                 self._get_features()["frame"] == current_step, dtype=float
             )
-            size = np.ones(len(alpha)) * 50
+            size = np.ones(len(alpha)) * self.scatter_point_size
 
             index_out_of_frame = alpha == 0
             alpha[index_out_of_frame] = 0.25
-            size[index_out_of_frame] = 35
+            size[index_out_of_frame] = self.scatter_point_size * 0.5
             self.plotting_widget.active_artist.alpha = alpha
             self.plotting_widget.active_artist.size = size
 
@@ -371,7 +375,7 @@ class PlotterWidget(BaseWidget):
         Updates the visibility of the frame highlighting in the plot.
         """
         # do nothing for histogram2d
-        if self.plotting_widget.active_artist == "HISTOGRAM2D":
+        if self.plotting_type == "HISTOGRAM2D":
             return
         
         if self.frame_highlighting_activated:
@@ -381,8 +385,28 @@ class PlotterWidget(BaseWidget):
                 len(self._get_features()), dtype=float
             )  # Reset alpha to 1 for all points
 
+    def _on_point_size_changed(self):
+        """
+        Called when the point size is changed.
+        Updates the size of the points in the scatter plot.
+        """
+        
+        if self.plotting_type != "SCATTER":
+            return
+
+        self.plotting_widget.active_artist.size = self.scatter_point_size
+        self.plot_needs_update.emit()
+
     # Connecting the widgets to actual object variables:
     # using getters and setters for flexibility
+
+    @property
+    def scatter_point_size(self):
+        return self.control_widget.spinBox_point_size.value()
+    
+    @scatter_point_size.setter
+    def scatter_point_size(self, val: int):
+        self.control_widget.spinBox_point_size.setValue(val)
 
     @property
     def frame_highlighting_activated(self):

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -182,6 +182,10 @@ class PlotterWidget(BaseWidget):
             self._on_bin_auto_toggled
         )
 
+        self.control_widget.checkBox_frame_highlighting.toggled.connect(
+            self._on_frame_highlighting_toggled
+        )
+
     def _on_finish_draw(self, color_indices: np.ndarray):
         """
         Called when user finsihes drawing. Will change the hue combo box to the
@@ -298,6 +302,9 @@ class PlotterWidget(BaseWidget):
         Called when the frame changes. Updates the alpha values of the points.
         """
 
+        if not self.frame_highlighting_activated:
+            return
+
         if "frame" in self._get_features().columns:
             current_step = self.viewer.dims.current_step[0]
             alpha = np.asarray(
@@ -358,8 +365,33 @@ class PlotterWidget(BaseWidget):
         self.control_widget.n_bins_box.setEnabled(not state)
         self.plot_needs_update.emit()
 
+    def _on_frame_highlighting_toggled(self):
+        """
+        Called when the frame highlighting checkbox is toggled.
+        Updates the visibility of the frame highlighting in the plot.
+        """
+        # do nothing for histogram2d
+        if self.plotting_widget.active_artist == "HISTOGRAM2D":
+            return
+        
+        if self.frame_highlighting_activated:
+            self._on_frame_changed(None)
+        else:
+            self.plotting_widget.active_artist.alpha = np.ones(
+                len(self._get_features()), dtype=float
+            )  # Reset alpha to 1 for all points
+
     # Connecting the widgets to actual object variables:
     # using getters and setters for flexibility
+
+    @property
+    def frame_highlighting_activated(self):
+        return self.control_widget.checkBox_frame_highlighting.isChecked()
+    
+    @frame_highlighting_activated.setter
+    def frame_highlighting(self, val: bool):
+        self.control_widget.checkBox_frame_highlighting.setChecked(val)
+
     @property
     def log_scale(self):
         return self.control_widget.log_scale_checkbutton.isChecked()

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -118,7 +118,6 @@ class PlotterWidget(BaseWidget):
         )
 
         # Setting Visibility Defaults
-        self.control_widget.cmap_container.setVisible(False)
         self.control_widget.bins_settings_container.setVisible(False)
         self.control_widget.additional_options_container.setVisible(False)
 
@@ -209,30 +208,6 @@ class PlotterWidget(BaseWidget):
 
         self.plot_needs_update.emit()
 
-    def _handle_advanced_options_widget_visibility(self):
-        """
-        Control visibility of overlay colormap box and log scale checkbox
-        based on the selected hue axis and active artist.
-        """
-        active_artist = self.plotting_widget.active_artist
-        # Control visibility of overlay colormap box and log scale checkbox
-        if self.hue_axis in self.categorical_columns:
-            self.control_widget.overlay_cmap_box.setEnabled(False)
-            self.control_widget.log_scale_checkbutton.setEnabled(False)
-            if isinstance(active_artist, Histogram2D):
-                # Enable if histogram to allow log scale of histogram itself
-                self.control_widget.log_scale_checkbutton.setEnabled(True)
-        else:
-            self.control_widget.overlay_cmap_box.setEnabled(True)
-            self.control_widget.log_scale_checkbutton.setEnabled(True)
-
-        if isinstance(active_artist, Histogram2D):
-            self.control_widget.cmap_container.setVisible(True)
-            self.control_widget.bins_settings_container.setVisible(True)
-        else:
-            self.control_widget.cmap_container.setVisible(False)
-            self.control_widget.bins_settings_container.setVisible(False)
-
     def _reset_axes_labels(self):
         """
         Clear the x and y axis labels in the plotting widget.
@@ -267,7 +242,6 @@ class PlotterWidget(BaseWidget):
         overlay_cmap = self.colormap_reference[
             (self.hue_axis in self.categorical_columns, self.plotting_type)
         ]
-        self._handle_advanced_options_widget_visibility()
         self._reset_axes_labels()
         active_artist = self.plotting_widget.active_artist
         active_artist.x_label_text = self.x_axis
@@ -347,11 +321,16 @@ class PlotterWidget(BaseWidget):
                 cat10_mod_cmap_first_transparent
             )
 
+            self.control_widget.scatter_settings_container.setVisible(False)
+            self.control_widget.bins_settings_container.setVisible(True)
+
         elif self.plotting_type == PlottingType.SCATTER.name:
             self.plotting_widget.active_artist = "SCATTER"
             self.plotting_widget.active_artist.overlay_colormap = (
                 cat10_mod_cmap
             )
+            self.control_widget.scatter_settings_container.setVisible(True)
+            self.control_widget.bins_settings_container.setVisible(False)
         self.plot_needs_update.emit()
 
     def _on_overlay_colormap_changed(self):

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -417,7 +417,7 @@ class PlotterWidget(BaseWidget):
         return self.control_widget.checkBox_frame_highlighting.isChecked()
     
     @frame_highlighting_activated.setter
-    def frame_highlighting(self, val: bool):
+    def frame_highlighting_activated(self, val: bool):
         self.control_widget.checkBox_frame_highlighting.setChecked(val)
 
     @property

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -397,9 +397,7 @@ class PlotterWidget(BaseWidget):
         
         if self.plotting_type != "SCATTER":
             return
-
         self.plotting_widget.active_artist.size = self.scatter_point_size
-        self.plot_needs_update.emit()
 
     # Connecting the widgets to actual object variables:
     # using getters and setters for flexibility

--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -533,6 +533,9 @@ class PlotterWidget(BaseWidget):
                     f"Layer {layer.name} does not have events.features or events.properties"
                 )
 
+        # make sure we use the correct frame highlighting settings
+        self._on_frame_highlighting_toggled()
+
     def _clean_up(self):
         """In case of empty layer selection"""
 

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -555,6 +555,41 @@ def test_histogram_support(make_napari_viewer, create_sample_layers):
     plotter_widget.plotting_type = "SCATTER"
 
 
+# only points is enough here
+@pytest.mark.parametrize(
+    "create_sample_layers",
+    [
+        create_multi_point_layer,
+    ],
+)
+def test_scatter_advanced_options(make_napari_viewer, create_sample_layers):
+    from napari_clusters_plotter import PlotterWidget
+    viewer = make_napari_viewer()
+    layer, layer2 = create_sample_layers()
+
+    # add layers to viewer
+    viewer.add_layer(layer)
+    viewer.add_layer(layer2)
+    plotter_widget = PlotterWidget(viewer)
+    viewer.window.add_dock_widget(plotter_widget, area="right")
+
+    plotter_widget.scatter_point_size = 10
+    assert np.all(plotter_widget.plotting_widget.active_artist.size == 10)
+
+    plotter_widget.frame_highlighting_activated = True
+    assert ~ np.all(
+        plotter_widget.plotting_widget.active_artist.alpha == 1
+    )
+
+    # select multiple layers and make sure that plot parameters are correct
+    viewer.layers.selection = (layer, layer2)
+    assert np.all(plotter_widget.plotting_widget.active_artist.size == 10)
+    assert ~ np.all(
+        plotter_widget.plotting_widget.active_artist.alpha == 1
+    )
+
+
+
 @pytest.mark.parametrize(
     "create_sample_layers",
     [

--- a/src/napari_clusters_plotter/_tests/test_plotter.py
+++ b/src/napari_clusters_plotter/_tests/test_plotter.py
@@ -510,8 +510,10 @@ def test_temporal_highlighting(make_napari_viewer, create_sample_layers):
 
     # check that the dots in the plotter widget update alpha and size
     # to highlight out-of and in-frame data points
-    assert plotter_widget.plotting_widget.active_artist.alpha.min() == 0.25
-    assert plotter_widget.plotting_widget.active_artist.size.min() == 35
+    oof_size = plotter_widget.scatter_point_size * plotter_widget._out_of_frame_size_factor
+    oof_alpha = plotter_widget._out_of_frame_alpha
+    assert plotter_widget.plotting_widget.active_artist.alpha.min() == oof_alpha
+    assert plotter_widget.plotting_widget.active_artist.size.min() == oof_size
 
 
 @pytest.mark.parametrize(

--- a/src/napari_clusters_plotter/plotter_inputs.ui
+++ b/src/napari_clusters_plotter/plotter_inputs.ui
@@ -170,6 +170,9 @@
             <property name="text">
              <string>Activate frame highlighting</string>
             </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
            </widget>
           </item>
           <item row="1" column="1">

--- a/src/napari_clusters_plotter/plotter_inputs.ui
+++ b/src/napari_clusters_plotter/plotter_inputs.ui
@@ -184,6 +184,9 @@
             <property name="minimum">
              <number>1</number>
             </property>
+            <property name="value">
+             <number>30</number>
+            </property>
            </widget>
           </item>
           <item row="1" column="2">

--- a/src/napari_clusters_plotter/plotter_inputs.ui
+++ b/src/napari_clusters_plotter/plotter_inputs.ui
@@ -23,7 +23,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="plotting_options">
       <attribute name="title">
@@ -116,6 +116,26 @@
          </layout>
         </widget>
        </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="QWidget" name="overlay_cmap_container" native="true">
+         <layout class="QGridLayout" name="gridLayout_6">
+          <item row="1" column="1">
+           <widget class="QComboBox" name="overlay_cmap_box">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Continuous colormap to display a feature as colors over plotted data.&lt;/p&gt;&lt;p&gt;Use the eye button in the plotter controls to hide/show the overlay colors.&lt;/p&gt;&lt;p&gt;To enale this, select a non-categorical feature in the &lt;span style=&quot; font-weight:600;&quot;&gt;Hue&lt;/span&gt; Combobox.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Overlay Colormap</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
        <item row="4" column="0" colspan="2">
         <widget class="QWidget" name="plotting_type_container" native="true">
          <layout class="QGridLayout" name="gridLayout">
@@ -139,125 +159,158 @@
          </layout>
         </widget>
        </item>
-       <item row="2" column="0" colspan="2">
-        <widget class="QWidget" name="overlay_cmap_container" native="true">
-         <layout class="QGridLayout" name="gridLayout_6">
+       <item row="6" column="0" colspan="2">
+        <widget class="QGroupBox" name="scatter_settings_container">
+         <property name="title">
+          <string>Scatter controls</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_8">
+          <item row="0" column="0">
+           <widget class="QCheckBox" name="checkBox_frame_highlighting">
+            <property name="text">
+             <string>Activate frame highlighting</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="1">
-           <widget class="QComboBox" name="overlay_cmap_box">
-            <property name="toolTip">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Continuous colormap to display a feature as colors over plotted data.&lt;/p&gt;&lt;p&gt;Use the eye button in the plotter controls to hide/show the overlay colors.&lt;/p&gt;&lt;p&gt;To enale this, select a non-categorical feature in the &lt;span style=&quot; font-weight:600;&quot;&gt;Hue&lt;/span&gt; Combobox.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <widget class="QLabel" name="label_9">
+            <property name="text">
+             <string>Point size</string>
             </property>
            </widget>
           </item>
           <item row="1" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Overlay Colormap</string>
+           <widget class="QSpinBox" name="spinBox_point_size">
+            <property name="minimum">
+             <number>1</number>
             </property>
            </widget>
+          </item>
+          <item row="1" column="2">
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Minimum</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>
        </item>
-       <item row="6" column="0" colspan="2">
-        <widget class="QWidget" name="bins_settings_container" native="true">
-         <property name="enabled">
-          <bool>true</bool>
+       <item row="7" column="0" colspan="2">
+        <widget class="QGroupBox" name="bins_settings_container">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_3">
-          <item>
-           <widget class="QLabel" name="label_6">
-            <property name="text">
-             <string>Number of Bins</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QWidget" name="manual_bins_container" native="true">
+         <property name="title">
+          <string>Histogram controls</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="0" column="1">
+           <widget class="QCheckBox" name="auto_bins_checkbox">
             <property name="enabled">
              <bool>true</bool>
             </property>
-            <layout class="QHBoxLayout" name="horizontalLayout">
-             <item>
-              <widget class="QCheckBox" name="auto_bins_checkbox">
-               <property name="enabled">
-                <bool>true</bool>
-               </property>
-               <property name="text">
-                <string>Auto</string>
-               </property>
-               <property name="checked">
-                <bool>true</bool>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QSpinBox" name="n_bins_box">
-               <property name="enabled">
-                <bool>false</bool>
-               </property>
-               <property name="minimum">
-                <number>1</number>
-               </property>
-               <property name="maximum">
-                <number>10000</number>
-               </property>
-               <property name="value">
-                <number>20</number>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="5" column="0" colspan="2">
-        <widget class="QWidget" name="cmap_container" native="true">
-         <layout class="QGridLayout" name="gridLayout_7">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_8">
             <property name="text">
-             <string>Histogram Colormap</string>
+             <string>Auto</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
+          <item row="1" column="2">
            <widget class="QComboBox" name="histogram_cmap_box">
             <property name="toolTip">
              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Continuous colormap to display the histogram data (not the colors overlay).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
            </widget>
           </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="7" column="0" colspan="2">
-        <widget class="QWidget" name="additional_options_container" native="true">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_5">
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>Hide non-selected clusters</string>
+          <item row="0" column="2">
+           <widget class="QSpinBox" name="n_bins_box">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="minimum">
+             <number>1</number>
+            </property>
+            <property name="maximum">
+             <number>10000</number>
+            </property>
+            <property name="value">
+             <number>20</number>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QCheckBox" name="non_selected_checkbutton">
+          <item row="1" column="0" colspan="2">
+           <widget class="QLabel" name="label_8">
             <property name="text">
-             <string/>
+             <string>Histogram Colormap</string>
             </property>
            </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_6">
+            <property name="text">
+             <string>Number of Bins</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <spacer name="horizontalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeType">
+             <enum>QSizePolicy::Minimum</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
           </item>
          </layout>
         </widget>
        </item>
       </layout>
      </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="additional_options_container" native="true">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="1" column="1">
+       <widget class="QCheckBox" name="non_selected_checkbutton">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Hide non-selected clusters</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
Fixes #444 

@zoccoler PR to fix what I noticed when I prepared the slides for the course. For a large number of points, the point sizes are waaaay too large to discern any clusters in the data. I added UI options to set the point size manually and to enable/disable the frame highlighting. In doing so, I also streamlined the handling of the advanced option's appearance/dissapearance a bit.

Future work *may* include some clever settings for points' edge width (the `linewidth` property) - it can happen, that for small point sizes, the face of a point is completely invisible due to the comparatively large border ^^"

## Copilot description

This pull request introduces several enhancements and refactors to the `napari_clusters_plotter` package, focusing on improving scatter plot functionality, adding advanced options for frame highlighting and point size adjustments, and restructuring the UI for better usability. Additionally, it includes updates to the test suite to ensure the new features are properly validated.

### Enhancements to Scatter Plot Functionality:

* Added support for frame highlighting and point size adjustments in scatter plots, controlled via new UI elements (`checkBox_frame_highlighting` and `spinBox_point_size`). These settings dynamically update the alpha and size of points based on the current frame and user-defined values. (`src/napari_clusters_plotter/_new_plotter_widget.py`, [[1]](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01R49-R52) [[2]](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01R318-R330) [[3]](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01R381-R425)

* Introduced new properties (`scatter_point_size` and `frame_highlighting_activated`) to encapsulate scatter plot settings, enabling easier access and modification. (`src/napari_clusters_plotter/_new_plotter_widget.py`, [src/napari_clusters_plotter/_new_plotter_widget.pyR381-R425](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01R381-R425))

### UI Improvements:

* Restructured the UI to include dedicated containers for scatter and histogram settings (`scatter_settings_container` and `bins_settings_container`), improving clarity and usability. (`src/napari_clusters_plotter/plotter_inputs.ui`, [[1]](diffhunk://#diff-645a2abe2612eee86a0a584b4947fb59c3ccb8d0a32f987eac8e4c732a83cd9bR119-R138) [[2]](diffhunk://#diff-645a2abe2612eee86a0a584b4947fb59c3ccb8d0a32f987eac8e4c732a83cd9bL142-R226)

* Adjusted the default visibility and layout of UI elements to better reflect the active plot type, ensuring relevant controls are displayed contextually. (`src/napari_clusters_plotter/plotter_inputs.ui`, [src/napari_clusters_plotter/plotter_inputs.uiL210-L261](diffhunk://#diff-645a2abe2612eee86a0a584b4947fb59c3ccb8d0a32f987eac8e4c732a83cd9bL210-L261))

### Refactoring and Code Simplification:

* Removed the `_handle_advanced_options_widget_visibility` method, simplifying visibility control logic by integrating it directly into relevant methods such as `_replot` and `_on_plot_type_changed`. (`src/napari_clusters_plotter/_new_plotter_widget.py`, [[1]](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01L212-L235) [[2]](diffhunk://#diff-5e5ef53b6cd18007b1c6ef70023699db72badc1a0820d69420edadb2f90ebe01L270)

### Test Suite Updates:

* Added tests for scatter plot advanced options, validating frame highlighting and point size functionality. (`src/napari_clusters_plotter/_tests/test_plotter.py`, [src/napari_clusters_plotter/_tests/test_plotter.pyR558-R592](diffhunk://#diff-2d655e0941ae671331bd4bc1e0682a27920b236d70a1623496683969eaa87c04R558-R592))

* Updated existing tests to accommodate new scatter plot settings, ensuring proper handling of alpha and size adjustments. (`src/napari_clusters_plotter/_tests/test_plotter.py`, [src/napari_clusters_plotter/_tests/test_plotter.pyL513-R516](diffhunk://#diff-2d655e0941ae671331bd4bc1e0682a27920b236d70a1623496683969eaa87c04L513-R516))