### PR TITLE
translate images through translate instead of grid

### DIFF
--- a/src/napari_clusters_plotter/_sample_data.py
+++ b/src/napari_clusters_plotter/_sample_data.py
@@ -2,6 +2,7 @@ import glob
 import os
 from pathlib import Path
 from typing import List
+
 import numpy as np
 
 
@@ -107,7 +108,6 @@ def tgmm_mini_dataset() -> List["LayerData"]:  # noqa: F821
 
 
 def bbbc_1_dataset() -> List["LayerData"]:  # noqa: F821
-    import napari
     import pandas as pd
     from skimage import io
 
@@ -125,20 +125,20 @@ def bbbc_1_dataset() -> List["LayerData"]:  # noqa: F821
     layers = []
 
     images = [io.imread(f) for f in raw_images]
-    labels = [
-        io.imread(f.replace(".tif", "_labels.tif")) for f in raw_images
-    ]
+    labels = [io.imread(f.replace(".tif", "_labels.tif")) for f in raw_images]
     features = [
         pd.read_csv(f.replace(".tif", "_features.csv")) for f in raw_images
     ]
 
     max_size = max([image.shape[0] for image in images])
 
-    for idx, (image, labels, features) in enumerate(zip(images, labels, features)):
+    for idx, (image, labels, features) in enumerate(
+        zip(images, labels, features)
+    ):
 
         translate_img_x = image.shape[0] / 2
         translate_img_y = image.shape[1] / 2
-        
+
         # calculate translate in grid
         margin = 0.1 * image.shape[0]  # 10% margin
         i_row = idx // n_cols

--- a/src/napari_clusters_plotter/_sample_data.py
+++ b/src/napari_clusters_plotter/_sample_data.py
@@ -132,7 +132,7 @@ def bbbc_1_dataset() -> List["LayerData"]:  # noqa: F821
 
     max_size = max([image.shape[0] for image in images])
 
-    for idx, (image, labels, features) in enumerate(
+    for idx, (image, label, feature) in enumerate(
         zip(images, labels, features)
     ):
 
@@ -156,11 +156,11 @@ def bbbc_1_dataset() -> List["LayerData"]:  # noqa: F821
         )
 
         ldtuple_labels = (
-            labels,
+            label,
             {
                 "name": Path(raw_images[idx]).stem + "_labels",
                 "translate": (translate_x, translate_y),
-                "features": features,
+                "features": feature,
             },
             "labels",
         )


### PR DESCRIPTION
This PR uses the`translate` property to put images in a grid rather than the grid view. This makes the grid view nicer for napari>=0.6.2

cc #442 

This pull request introduces enhancements to the `bbbc_1_dataset` function in the `src/napari_clusters_plotter/_sample_data.py` file, improving the organization of image data in a grid layout and adding new functionality for translating images and labels. Additionally, it includes a minor import update.

### Enhancements to `bbbc_1_dataset` function:

* Added logic to compute the number of rows (`n_rows`) and columns (`n_cols`) for arranging images in a grid layout. This improves the visual organization of the dataset.
* Introduced translation calculations (`translate_x` and `translate_y`) to position images and labels within the grid, including a margin for spacing.
* Updated the layer tuples (`ldtuple_image` and `ldtuple_labels`) to include the `translate` property, ensuring proper placement in the grid.
* Removed viewer-specific grid settings (`napari.current_viewer.grid.enabled` and `napari.current_viewer.grid.stride`) to decouple the function from viewer-specific behavior.

### Import update:

* Added `numpy` (`np`) import to support mathematical operations such as `ceil` for grid layout calculations.