### PR TITLE
remove unconnected contextMenuEvent

### DIFF
--- a/src/napari_clusters_plotter/_new_plotter_widget.py
+++ b/src/napari_clusters_plotter/_new_plotter_widget.py
@@ -128,9 +128,6 @@ class PlotterWidget(BaseWidget):
         self.control_widget.bins_settings_container.setVisible(False)
         self.control_widget.additional_options_container.setVisible(False)
 
-    def contextMenuEvent(self, event):
-        self.context_menu.exec_(event.globalPos())
-
     def _on_export_clusters(self):
         """
         Export the selected cluster to a new layer.


### PR DESCRIPTION
Closes #456 

Hi @zoccoler , I think this fixes the error you saw. In essence, I removed the previous functionality for exporting subclusters with a right-click triggered context menu but forgot to remove the callback to the right click itself.